### PR TITLE
Added support for single items, posting, and search  

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ import pypaperless
 
 async def main():
     api = pypaperless.PaperlessAPI("http://127.0.0.1:9120", "SUPER_SECRET_API_TOKEN_HERE")
+    # alternative: api = pypaperless.PaperlessAPI("http://127.0.0.1:9120", username="user", password="pass")
 
     correspondents = await api.get_correspondents()
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ doctypes = await api.get_document_types()
 tags = await api.get_tags()
 views = await api.get_saved_views()
 documents = await api.get_documents()
+tasks = await apt.get_tasks()
 ```
 
 Request a single item by id from an endpoint.
@@ -38,6 +39,8 @@ Request a single item by id from an endpoint.
 doctype = await api.get_document_type(3)
 tag = await api.get_tag(6)
 document = await api.get_document(6)
+task = await api.get_task(123)
+by_task_id = await api.get_task_by_task_id("fdaa724b-xxxx-yyyy-aaf8-edc5c113c656")
 ```
 
 Post a document to Paperless. Only the file is mandatory, title, creation date correspondent id, and document type id are optional. Tags are crurrently not supported.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,20 @@ tags = await api.get_tags()
 views = await api.get_saved_views()
 documents = await api.get_documents()
 ```
+
+Request a single item by id from an endpoint.
+```python
+doctype = await api.get_document_type(3)
+tag = await api.get_tag(6)
+document = await api.get_document(6)
+```
+
+Post a document to Paperless. Only the file is mandatory, title, creation date correspondent id, and document type id are optional. Tags are crurrently not supported.
+```python
+await api.post_document("./invoice.pdf",title="Invoice bedroom closet")
+```
+
+Search for a document and receive a list of results. Search syntax is the same as in Paperless: https://docs.paperless-ngx.com/usage/#basic-usage_searching.
+```python
+matching_documents = await api.search("bedroom*")
+```

--- a/pypaperless/auth.py
+++ b/pypaperless/auth.py
@@ -1,13 +1,20 @@
 from aiohttp import ClientSession, ClientResponse
-
+import base64
 
 class Auth:
     """Class to make authenticated requests."""
+
+    token: str = ""
+    basic_auth: str = ""
 
     def __init__(self, endpoint: str, token: str):
         """Initialize the auth."""
         self.basepath = endpoint
         self.token = token
+    
+    def __init__(self, endpoint: str, username: str, password: str):
+        self.basepath = endpoint
+        self.basic_auth = base64.b64encode(f"{username}:{password}".encode()).decode()
 
     async def request(self, session: ClientSession, method: str, path: str, **kwargs) -> ClientResponse:
         uri = f"{self.basepath}/{path}/"
@@ -32,7 +39,10 @@ class Auth:
             params = dict(params)
 
         params["format"] = "json"
-        headers["authorization"] = f"Token {self.token}"
+        if self.token:
+            headers["authorization"] = f"Token {self.token}"
+        else:
+            headers["authorization"] = f"Basic {self.basic_auth}"
 
         return await session.request(
             method, uri, **kwargs, headers=headers,

--- a/pypaperless/auth.py
+++ b/pypaperless/auth.py
@@ -7,14 +7,13 @@ class Auth:
     token: str = ""
     basic_auth: str = ""
 
-    def __init__(self, endpoint: str, token: str):
+    def __init__(self, endpoint: str, token: str = None, username: str = None, password: str = None):
         """Initialize the auth."""
         self.basepath = endpoint
-        self.token = token
-    
-    def __init__(self, endpoint: str, username: str, password: str):
-        self.basepath = endpoint
-        self.basic_auth = base64.b64encode(f"{username}:{password}".encode()).decode()
+        if token:
+            self.token = token
+        if username and password:
+            self.basic_auth = base64.b64encode(f"{username}:{password}".encode()).decode()
 
     async def request(self, session: ClientSession, method: str, path: str, **kwargs) -> ClientResponse:
         uri = f"{self.basepath}/{path}/"

--- a/pypaperless/model.py
+++ b/pypaperless/model.py
@@ -262,3 +262,56 @@ class Document:
     def archived_file_name(self) -> str:
         """Return the archived_file_name."""
         return self.raw_data["archived_file_name"]
+
+class Task:
+    """Class that represents a task object in the paperless API"""
+
+    def __init__(self, raw_data: dict, auth: Auth):
+        """Initialize a task object."""
+        self.raw_data = raw_data
+        self.auth = auth
+
+    @property
+    def task_id(self) -> str:
+        """Return the task id."""
+        return self.raw_data["task_id"]
+
+    @property
+    def task_file_name(self) -> str:
+        """Return the task file name."""
+        return self.raw_data["task_file_name"]
+
+    @property
+    def date_created(self) -> datetime:
+        """Return the creation date."""
+        return self.raw_data["date_created"]
+    
+    @property
+    def date_done(self) -> datetime:
+        """Return the finishing date."""
+        return self.raw_data["date_done"]
+
+    @property
+    def type(self) -> str:
+        """Return the type."""
+        return self.raw_data["type"]
+
+    @property
+    def status(self) -> str:
+        """Return the status."""
+        return self.raw_data["status"]
+
+    @property
+    def result(self) -> str:
+        """Return the result string."""
+        return self.raw_data["result"]
+
+    @property
+    def result(self) -> bool:
+        """Return if the task was acknowledged"""
+        return self.raw_data["acknowledged"]
+    
+    @property
+    def related_document(self) -> int:
+        """Return the related document id"""
+        return self.raw_data["related_document"]    

--- a/pypaperless/paperless.py
+++ b/pypaperless/paperless.py
@@ -10,13 +10,9 @@ import aiohttp
 class PaperlessAPI:
     """Class to communicate with the paginated API."""
 
-    def __init__(self, endpoint: str, token: str):
-        """Initialize the API and store the auth so we can make token-based requests."""
-        self.auth = Auth(endpoint, token)
-
-    def __init__(self, endpoint: str, username: str, password: str):
-        """Initialize the API and store the auth so we can make token-based requests."""
-        self.auth = Auth(endpoint, username, password)
+    def __init__(self, endpoint: str, token: str = None, username: str = None, password: str = None):
+        """Initialize the API and store the auth so we can make token-based or Basic-auth requests."""
+        self.auth = Auth(endpoint=endpoint,token=token,username=username, password=password)
 
     async def __get_paginated_results(self, path: str, isa: object, params = None) -> List[object]:
         """Walk through the pagination and return a list of objects of type <isa>."""

--- a/pypaperless/paperless.py
+++ b/pypaperless/paperless.py
@@ -138,8 +138,9 @@ class PaperlessAPI:
                 form.add_field("correspondent", f"{correspondent}")
             if document_type:
                 form.add_field("document_type", f"{document_type}")            
-            for tag in tags:
-                form.add_field("tags",f"{tag}")            
+            if tags:
+                for tag in tags:
+                    form.add_field("tags",f"{tag}")            
 
             resp = await self.auth.request(session=session, method="post", path="documents/post_document", data=form)
             resp.raise_for_status()

--- a/pypaperless/paperless.py
+++ b/pypaperless/paperless.py
@@ -1,4 +1,5 @@
 from typing import List
+from datetime import datetime
 
 from .auth import Auth
 from .model import *
@@ -12,6 +13,10 @@ class PaperlessAPI:
     def __init__(self, endpoint: str, token: str):
         """Initialize the API and store the auth so we can make token-based requests."""
         self.auth = Auth(endpoint, token)
+
+    def __init__(self, endpoint: str, username: str, password: str):
+        """Initialize the API and store the auth so we can make token-based requests."""
+        self.auth = Auth(endpoint, username, password)
 
     async def __get_paginated_results(self, path: str, isa: object) -> List[object]:
         """Walk through the pagination and return a list of objects of type <isa>."""
@@ -37,23 +42,67 @@ class PaperlessAPI:
                     break
 
         return results
+    
+    async def __get_result(self, path: str, isa: object) -> object:
+        """ Return an objects of type <isa>."""
+        json = {}
+
+        async with aiohttp.ClientSession() as session:
+            resp = await self.auth.request(session, "get", path)
+            resp.raise_for_status()
+
+            json = dict(await resp.json())
+
+            return isa(json, self.auth)
+    
+    async def get_correspondent(self, id: int) -> Correspondent:
+        """Return single correspondent by id."""
+        return await self.__get_result(f"correspondents/{id}", Correspondent)
 
     async def get_correspondents(self) -> List[Correspondent]:
         """Return all correspondents."""
         return await self.__get_paginated_results("correspondents", Correspondent)
 
+    async def get_document_type(self, id: int) -> DocumentType:
+        """Return single document type by id."""
+        return await self.__get_result(f"document_type/{id}", DocumentType)
+
     async def get_document_types(self) -> List[DocumentType]:
         """Return all document types."""
         return await self.__get_paginated_results("document_types", DocumentType)
 
+    async def get_tag(self, id: int) -> Tag:
+        """Return single tag by id."""
+        return await self.__get_result(f"tags/{id}", Tag)
+    
     async def get_tags(self) -> List[Tag]:
         """Return all tags."""
         return await self.__get_paginated_results("tags", Tag)
-
+    
     async def get_saved_views(self) -> List[SavedView]:
         """Return all saved views."""
         return await self.__get_paginated_results("saved_views", SavedView)
 
+    async def get_document(self, id: int) -> Document:
+        return await self.__get_result(f"documents/{id}", Document)
+
     async def get_documents(self) -> List[Document]:
         """Return all documents."""
         return await self.__get_paginated_results("documents", Document)
+    
+    async def post_document(self, file, title: str = "", created: datetime = None, correspondent: int = None, document_type: int = None):
+        """Post new document."""
+        async with aiohttp.ClientSession() as session:
+            data = {
+                "document": open(file, 'rb'),
+                "title": f"{title}",
+            }
+            if created:
+                data["created"] = f"{created}"
+            if correspondent:
+                data["correspondent"] = f"{correspondent}"
+            if document_type:
+                data["document_type"] = f"{document_type}"
+
+            resp = await self.auth.request(session=session, method="post", path="documents/post_document/", data=data)
+            resp.raise_for_status()

--- a/pypaperless/paperless.py
+++ b/pypaperless/paperless.py
@@ -18,7 +18,7 @@ class PaperlessAPI:
         """Initialize the API and store the auth so we can make token-based requests."""
         self.auth = Auth(endpoint, username, password)
 
-    async def __get_paginated_results(self, path: str, isa: object) -> List[object]:
+    async def __get_paginated_results(self, path: str, isa: object, params = None) -> List[object]:
         """Walk through the pagination and return a list of objects of type <isa>."""
         json = {}
         results = []
@@ -26,7 +26,7 @@ class PaperlessAPI:
         async with aiohttp.ClientSession() as session:
             while True:
                 if not "next" in json:
-                    resp = await self.auth.request(session, "get", path)
+                    resp = await self.auth.request(session, "get", path, params=params)
                 else:
                     resp = await self.auth.request_raw(session, "get", json["next"])
                 resp.raise_for_status()
@@ -106,3 +106,8 @@ class PaperlessAPI:
 
             resp = await self.auth.request(session=session, method="post", path="documents/post_document/", data=data)
             resp.raise_for_status()
+    
+    async def search(self, query: str) -> List[Document]:
+        params = {}
+        params["query"] = query
+        return await self.__get_paginated_results("documents", Document, params)


### PR DESCRIPTION
Hi @tb1337 

I have added support in your Paperless API for requesting single items (documents, tags, etc.) as well as posting new PDF documents, and searching for documents in Paperless. 

Would be great if you integrate these changes.

Cheers
André