### PR TITLE
Add better request/response handling

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -20,4 +20,4 @@ jobs:
         uses: ludeeus/action-require-labels@1.0.0
         with:
           labels: >-
-            breaking change, bug, chore, enhancement, refactor
+            breaking change, bug, chore, enhancement, refactor, documentation

--- a/pypaperless/__init__.py
+++ b/pypaperless/__init__.py
@@ -215,7 +215,7 @@ class Paperless:  # pylint: disable=too-many-instance-attributes
     ) -> dict[str, Any]:
         """Make a request to the api and parse response json to dict."""
         async with self.generate_request(method, endpoint, **kwargs) as res:
-            self.logger.debug("Request %s (%d): %s", method.upper(), res.status, res.url)
+            self.logger.debug("Json-Request %s (%d): %s", method.upper(), res.status, res.url)
 
             # bad request
             if res.status == 400:
@@ -238,7 +238,7 @@ class Paperless:  # pylint: disable=too-many-instance-attributes
     ) -> bytes:
         """Make a request to the api and return response as bytes."""
         async with self.generate_request(method, endpoint, **kwargs) as res:
-            self.logger.debug("Download %s (%d): %s", method.upper(), res.status, res.url)
+            self.logger.debug("File-Request %s (%d): %s", method.upper(), res.status, res.url)
 
             # bad request
             if res.status == 400:

--- a/pypaperless/api/base.py
+++ b/pypaperless/api/base.py
@@ -44,7 +44,7 @@ class BaseEndpoint(Generic[RT]):
 
     async def list(self) -> list[int]:
         """Return a list of all entity ids, if applicable."""
-        res = await self._paperless.request("get", self.endpoint)
+        res = await self._paperless.request_json("get", self.endpoint)
         if "all" in res:
             return res["all"]
 
@@ -70,7 +70,7 @@ class BaseEndpoint(Generic[RT]):
         if "page_size" not in kwargs:
             kwargs["page_size"] = self.request_page_size
 
-        res = await self._paperless.request("get", self.endpoint, params=kwargs)
+        res = await self._paperless.request_json("get", self.endpoint, params=kwargs)
         return PaginatedResult(
             kwargs["page"],
             kwargs["page"] + 1 if res["next"] else None,
@@ -91,7 +91,7 @@ class BaseEndpoint(Generic[RT]):
     async def one(self, idx: int) -> RT:
         """Request exactly one entity by id."""
         url = f"{self.endpoint}/{idx}"
-        res = await self._paperless.request("get", url)
+        res = await self._paperless.request_json("get", url)
         return dataclass_from_dict(self.endpoint_cls, res)
 
 
@@ -100,7 +100,7 @@ class BaseEndpointCrudMixin:
 
     async def create(self: BaseEndpoint, obj: PaperlessPost) -> RT:
         """Create a new entity. Raise on failure."""
-        res = await self._paperless.request(
+        res = await self._paperless.request_json(
             "post",
             self.endpoint,
             json=dataclass_to_dict(obj),
@@ -110,7 +110,7 @@ class BaseEndpointCrudMixin:
     async def update(self: BaseEndpoint, obj: RT) -> RT:
         """Update an existing entity. Raise on failure."""
         url = f"{self.endpoint}/{obj.id}"
-        res = await self._paperless.request(
+        res = await self._paperless.request_json(
             "put", url, json=dataclass_to_dict(obj, skip_none=False)
         )
         return dataclass_from_dict(self.endpoint_cls, res)
@@ -118,7 +118,7 @@ class BaseEndpointCrudMixin:
     async def delete(self: BaseEndpoint, obj: RT) -> bool:
         """Delete an existing entity. Raise on failure."""
         url = f"{self.endpoint}/{obj.id}"
-        await self._paperless.request("delete", url)
+        await self._paperless.request_json("delete", url)
         return True
 
 

--- a/pypaperless/api/documents.py
+++ b/pypaperless/api/documents.py
@@ -36,7 +36,7 @@ class DocumentNotesService(BaseService):
         """Request document notes of given document."""
         idx = _get_document_id_helper(obj)
         url = f"{self.endpoint}/{idx}/notes"
-        res = await self._paperless.request("get", url)
+        res = await self._paperless.request_json("get", url)
 
         # We have to transform data here slightly.
         # There are two major differences in the data depending on which endpoint is requested.
@@ -54,7 +54,7 @@ class DocumentNotesService(BaseService):
     async def create(self, obj: DocumentNotePost) -> None:
         """Create a new document note. Raises on failure."""
         url = f"{self.endpoint}/{obj.document}/notes"
-        await self._paperless.request("post", url, json=dataclass_to_dict(obj))
+        await self._paperless.request_json("post", url, json=dataclass_to_dict(obj))
 
     async def delete(self, obj: DocumentNote) -> None:
         """Delete an existing document note. Raises on failure."""
@@ -62,7 +62,7 @@ class DocumentNotesService(BaseService):
         params = {
             "id": obj.id,
         }
-        await self._paperless.request("delete", url, params=params)
+        await self._paperless.request_json("delete", url, params=params)
 
 
 class DocumentFilesService(BaseService):
@@ -75,7 +75,7 @@ class DocumentFilesService(BaseService):
     ) -> bytes:
         """Request a child endpoint."""
         url = f"{self.endpoint}/{idx}/{path}"
-        return await self._paperless.request("get", url)
+        return await self._paperless.request_file("get", url)
 
     async def download(self, obj: DocumentOrIdType) -> bytes:
         """Request document endpoint for downloading the actual file."""
@@ -126,12 +126,12 @@ class DocumentsEndpoint(BaseEndpoint[type[Document]], BaseEndpointCrudMixin):
                 form.add_field("tags", f"{tag}")
 
         url = f"{self.endpoint}/post_document/"
-        res = await self._paperless.request("post", url, data=form)
+        res = await self._paperless.request_json("post", url, data=form)
         return str(res)
 
     async def meta(self, obj: DocumentOrIdType) -> RT:
         """Request document metadata of given document."""
         idx = _get_document_id_helper(obj)
         url = f"{self.endpoint}/{idx}/metadata"
-        res = await self._paperless.request("get", url)
+        res = await self._paperless.request_json("get", url)
         return dataclass_from_dict(DocumentMetaInformation, res)

--- a/pypaperless/api/tasks.py
+++ b/pypaperless/api/tasks.py
@@ -21,7 +21,7 @@ class TasksEndpoint(BaseEndpoint[type[Task]]):
         **kwargs: dict[str, Any],
     ) -> list[RT]:
         """Request entities."""
-        res = await self._paperless.request("get", self.endpoint, params=kwargs)
+        res = await self._paperless.request_json("get", self.endpoint, params=kwargs)
         return [dataclass_from_dict(self.endpoint_cls, item) for item in res]
 
     async def iterate(
@@ -38,5 +38,5 @@ class TasksEndpoint(BaseEndpoint[type[Task]]):
         params = {
             "task_id": idx,
         }
-        res = await self._paperless.request("get", self.endpoint, params=params)
+        res = await self._paperless.request_json("get", self.endpoint, params=params)
         return dataclass_from_dict(self.endpoint_cls, res.pop())

--- a/pypaperless/errors.py
+++ b/pypaperless/errors.py
@@ -2,8 +2,12 @@
 
 
 class PaperlessException(Exception):
-    """Base exception for paperless."""
+    """Base exception for PyPaperless."""
 
 
 class BadRequestException(PaperlessException):
-    """Raised when requesting wrong data."""
+    """Raise when requesting wrong data."""
+
+
+class DataNotExpectedException(PaperlessException):
+    """Raise when expecting a type and receiving something else."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,8 +36,7 @@ async def paperless() -> Paperless:
         d = load_fixture_data("data.json")
         return d["endpoints"]
 
-    with patch.object(api, "request", return_value=endpoints_data()):
+    with patch.object(api, "request_json", return_value=endpoints_data()):
         await api.initialize()
-
     yield api
     await api.close()

--- a/tests/pypaperless/test_consumption_templates.py
+++ b/tests/pypaperless/test_consumption_templates.py
@@ -17,7 +17,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["consumption_templates"]):
+    with patch.object(paperless, "request_json", return_value=data["consumption_templates"]):
         result = await paperless.consumption_templates.list()
 
         assert isinstance(result, list)
@@ -34,7 +34,7 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["consumption_templates"]):
+    with patch.object(paperless, "request_json", return_value=data["consumption_templates"]):
         async for item in paperless.consumption_templates.iterate():
             assert isinstance(item, ConsumptionTemplate)
 
@@ -42,7 +42,7 @@ async def test_iterate(paperless: Paperless, data):
 async def test_one(paperless: Paperless, data):
     """Test one."""
     with patch.object(
-        paperless, "request", return_value=data["consumption_templates"]["results"][0]
+        paperless, "request_json", return_value=data["consumption_templates"]["results"][0]
     ):
         item = await paperless.consumption_templates.one(72)
 

--- a/tests/pypaperless/test_correspondents.py
+++ b/tests/pypaperless/test_correspondents.py
@@ -17,7 +17,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["correspondents"]):
+    with patch.object(paperless, "request_json", return_value=data["correspondents"]):
         result = await paperless.correspondents.list()
 
         assert isinstance(result, list)
@@ -34,14 +34,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["correspondents"]):
+    with patch.object(paperless, "request_json", return_value=data["correspondents"]):
         async for item in paperless.correspondents.iterate():
             assert isinstance(item, Correspondent)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["correspondents"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["correspondents"]["results"][0]):
         item = await paperless.correspondents.one(72)
 
         assert isinstance(item, Correspondent)

--- a/tests/pypaperless/test_custom_fields.py
+++ b/tests/pypaperless/test_custom_fields.py
@@ -17,7 +17,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["custom_fields"]):
+    with patch.object(paperless, "request_json", return_value=data["custom_fields"]):
         result = await paperless.custom_fields.list()
 
         assert isinstance(result, list)
@@ -34,14 +34,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["custom_fields"]):
+    with patch.object(paperless, "request_json", return_value=data["custom_fields"]):
         async for item in paperless.custom_fields.iterate():
             assert isinstance(item, CustomField)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["custom_fields"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["custom_fields"]["results"][0]):
         item = await paperless.custom_fields.one(72)
 
         assert isinstance(item, CustomField)

--- a/tests/pypaperless/test_document_types.py
+++ b/tests/pypaperless/test_document_types.py
@@ -17,7 +17,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["document_types"]):
+    with patch.object(paperless, "request_json", return_value=data["document_types"]):
         result = await paperless.document_types.list()
 
         assert isinstance(result, list)
@@ -34,14 +34,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["document_types"]):
+    with patch.object(paperless, "request_json", return_value=data["document_types"]):
         async for item in paperless.document_types.iterate():
             assert isinstance(item, DocumentType)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["document_types"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["document_types"]["results"][0]):
         item = await paperless.document_types.one(72)
 
         assert isinstance(item, DocumentType)

--- a/tests/pypaperless/test_documents.py
+++ b/tests/pypaperless/test_documents.py
@@ -17,7 +17,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["documents"]):
+    with patch.object(paperless, "request_json", return_value=data["documents"]):
         result = await paperless.documents.list()
 
         assert isinstance(result, list)
@@ -34,14 +34,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["documents"]):
+    with patch.object(paperless, "request_json", return_value=data["documents"]):
         async for item in paperless.documents.iterate():
             assert isinstance(item, Document)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["documents"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["documents"]["results"][0]):
         item = await paperless.documents.one(72)
 
         assert isinstance(item, Document)

--- a/tests/pypaperless/test_groups.py
+++ b/tests/pypaperless/test_groups.py
@@ -16,7 +16,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["groups"]):
+    with patch.object(paperless, "request_json", return_value=data["groups"]):
         result = await paperless.groups.list()
 
         assert isinstance(result, list)
@@ -33,14 +33,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["groups"]):
+    with patch.object(paperless, "request_json", return_value=data["groups"]):
         async for item in paperless.groups.iterate():
             assert isinstance(item, Group)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["groups"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["groups"]["results"][0]):
         item = await paperless.groups.one(72)
 
         assert isinstance(item, Group)

--- a/tests/pypaperless/test_mail_accounts.py
+++ b/tests/pypaperless/test_mail_accounts.py
@@ -16,7 +16,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["mail_accounts"]):
+    with patch.object(paperless, "request_json", return_value=data["mail_accounts"]):
         result = await paperless.mail_accounts.list()
 
         assert isinstance(result, list)
@@ -33,14 +33,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["mail_accounts"]):
+    with patch.object(paperless, "request_json", return_value=data["mail_accounts"]):
         async for item in paperless.mail_accounts.iterate():
             assert isinstance(item, MailAccount)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["mail_accounts"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["mail_accounts"]["results"][0]):
         item = await paperless.mail_accounts.one(72)
 
         assert isinstance(item, MailAccount)

--- a/tests/pypaperless/test_mail_rules.py
+++ b/tests/pypaperless/test_mail_rules.py
@@ -16,7 +16,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["mail_rules"]):
+    with patch.object(paperless, "request_json", return_value=data["mail_rules"]):
         result = await paperless.mail_rules.list()
 
         assert isinstance(result, list)
@@ -33,14 +33,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["mail_rules"]):
+    with patch.object(paperless, "request_json", return_value=data["mail_rules"]):
         async for item in paperless.mail_rules.iterate():
             assert isinstance(item, MailRule)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["mail_rules"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["mail_rules"]["results"][0]):
         item = await paperless.mail_rules.one(72)
 
         assert isinstance(item, MailRule)

--- a/tests/pypaperless/test_saved_views.py
+++ b/tests/pypaperless/test_saved_views.py
@@ -16,7 +16,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["saved_views"]):
+    with patch.object(paperless, "request_json", return_value=data["saved_views"]):
         result = await paperless.saved_views.list()
 
         assert isinstance(result, list)
@@ -33,14 +33,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["saved_views"]):
+    with patch.object(paperless, "request_json", return_value=data["saved_views"]):
         async for item in paperless.saved_views.iterate():
             assert isinstance(item, SavedView)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["saved_views"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["saved_views"]["results"][0]):
         item = await paperless.saved_views.one(72)
 
         assert isinstance(item, SavedView)

--- a/tests/pypaperless/test_storage_paths.py
+++ b/tests/pypaperless/test_storage_paths.py
@@ -17,7 +17,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["storage_paths"]):
+    with patch.object(paperless, "request_json", return_value=data["storage_paths"]):
         result = await paperless.storage_paths.list()
 
         assert isinstance(result, list)
@@ -34,14 +34,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["storage_paths"]):
+    with patch.object(paperless, "request_json", return_value=data["storage_paths"]):
         async for item in paperless.storage_paths.iterate():
             assert isinstance(item, StoragePath)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["storage_paths"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["storage_paths"]["results"][0]):
         item = await paperless.storage_paths.one(72)
 
         assert isinstance(item, StoragePath)

--- a/tests/pypaperless/test_tags.py
+++ b/tests/pypaperless/test_tags.py
@@ -17,7 +17,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["tags"]):
+    with patch.object(paperless, "request_json", return_value=data["tags"]):
         result = await paperless.tags.list()
 
         assert isinstance(result, list)
@@ -34,14 +34,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["tags"]):
+    with patch.object(paperless, "request_json", return_value=data["tags"]):
         async for item in paperless.tags.iterate():
             assert isinstance(item, Tag)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["tags"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["tags"]["results"][0]):
         item = await paperless.tags.one(72)
 
         assert isinstance(item, Tag)

--- a/tests/pypaperless/test_tasks.py
+++ b/tests/pypaperless/test_tasks.py
@@ -17,7 +17,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["tasks"]):
+    with patch.object(paperless, "request_json", return_value=data["tasks"]):
         result = await paperless.tasks.list()
 
         # tasks have no list-all attribute...
@@ -32,14 +32,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["tasks"]):
+    with patch.object(paperless, "request_json", return_value=data["tasks"]):
         async for item in paperless.tasks.iterate():
             assert isinstance(item, Task)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["tasks"]):
+    with patch.object(paperless, "request_json", return_value=data["tasks"]):
         item = await paperless.tasks.one("bd2de639-5ecd-4bc1-ab3d-106908ef00e1")
 
         assert isinstance(item, Task)

--- a/tests/pypaperless/test_users.py
+++ b/tests/pypaperless/test_users.py
@@ -16,7 +16,7 @@ async def test_endpoint(paperless: Paperless) -> None:
 
 async def test_list_and_get(paperless: Paperless, data):
     """Test list."""
-    with patch.object(paperless, "request", return_value=data["users"]):
+    with patch.object(paperless, "request_json", return_value=data["users"]):
         result = await paperless.users.list()
 
         assert isinstance(result, list)
@@ -33,14 +33,14 @@ async def test_list_and_get(paperless: Paperless, data):
 
 async def test_iterate(paperless: Paperless, data):
     """Test iterate."""
-    with patch.object(paperless, "request", return_value=data["users"]):
+    with patch.object(paperless, "request_json", return_value=data["users"]):
         async for item in paperless.users.iterate():
             assert isinstance(item, User)
 
 
 async def test_one(paperless: Paperless, data):
     """Test one."""
-    with patch.object(paperless, "request", return_value=data["users"]["results"][0]):
+    with patch.object(paperless, "request_json", return_value=data["users"]["results"][0]):
         item = await paperless.users.one(72)
 
         assert isinstance(item, User)


### PR DESCRIPTION
Split ```paperless.request()``` into three functions:
1. ```paperless.generate_request()```, which returns a ClientResponse object
2. ```paperless.request_json()```, which expects a json string and returns a dict
3. ```paperless.request_file()```, which returns the response content as bytes

That change enables developers to create raw requests by themselves, if needed.

Updated related tests, too.

Resolves #11.