### PR TITLE
Fix hardcoded http in url (#49)

### DIFF
--- a/docs/SESSION.md
+++ b/docs/SESSION.md
@@ -1,5 +1,15 @@
 # Handling a session
 
+- [Connect to Paperless-ngx](#connect-to-paperless-ngx)
+  - [Some rules](#some-rules)
+  - [By url object](#by-url-object)
+  - [By url string](#by-url-string)
+  - [Force usage of http](#force-usage-of-http)
+  - [More](#more)
+    - [Customize aiohttp.ClientSession](#customize-aiohttpclientsession)
+    - [Customize aiohttp.ClientSession.request](#customize-aiohttpclientsessionrequest-kwargs)
+- [Start working with your data](#start-working-with-your-data)
+
 Just import the module and go on.
 
 ```python
@@ -13,6 +23,76 @@ paperless = Paperless("localhost:8000", "your-secret-token")
 
 asyncio.run(main())
 ```
+
+## Connect to Paperless-ngx
+
+*PyPaperless* makes use of *YARL* and applies some logic to the path when instantiating the Paperless object.
+
+### Some rules
+
+*PyPaperless* checks the passed urls and magically makes things work for you. Or not, in some cases. So be aware of the following rules:
+
+1. Isn't a scheme applied to it? Apply `https`.
+2. Is `http` explicitly used in it? Okay, continue with `http` :dizzy_face:.
+3. Doesn't it end with `/api`? Append `/api`.
+
+### By url object
+
+```python
+from yarl import URL
+
+# your desired URL object
+url = URL("homelab.lan").with_path("/path/to/paperless")
+paperless = Paperless(url, "your-secret-token")
+```
+
+Connects to `https://homelab.lan/path/to/paperless/api`.
+
+### By url string
+
+If you don't want to create a YARL url object, simply pass a string to the Paperless object.
+
+```python
+paperless = Paperless("paperless.lan", "your-secret-token")
+```
+
+Connects to `https://paperless.lan/api`.
+
+### Force usage of http
+
+As mentioned above, `http` is also possible. Just call is explicitly.
+
+```python
+paperless = Paperless("http://paperless.lan", "your-secret-token")
+```
+
+Connects to `http://paperless.lan/api`.
+
+It is not possible to force `http`-usage by just applying a port number. `paperless.lan:80` will result in connecting to it via `https`, even if it seems odd. Well, use `scheme://` which is a far more clear intention, and everything is fine.
+
+### More
+
+#### Customize `aiohttp.ClientSession`
+
+If you want to use an already existing `aiohttp.ClientSession`, pass it to the Paperless object.
+
+```python
+import aiohttp
+
+your_session = aiohttp.ClientSession()
+
+paperless = Paperless("your-url", "your-token", session=your_session)
+```
+
+#### Customize `aiohttp.ClientSession.request` kwargs
+
+You may want to pass custom data (f.e. ssl context) to the `request()` method, which is internally called by *PyPaperless* on each http-request. Pass it to the Paperless object.
+
+```python
+paperless = Paperless("your-url", "your-token", request_opts={...})
+```
+
+## Start working with your data
 
 Now you can utilize the Paperless object.
 

--- a/pypaperless/__init__.py
+++ b/pypaperless/__init__.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 import aiohttp
+from yarl import URL
 
 from .controllers import (
     ConsumptionTemplatesController,
@@ -32,7 +33,7 @@ class Paperless:  # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,
-        host: str,
+        url: str | URL,
         token: str,
         request_opts: dict[str, Any] | None = None,
         session: aiohttp.ClientSession | None = None,
@@ -41,16 +42,29 @@ class Paperless:  # pylint: disable=too-many-instance-attributes
         Initialize the Paperless api instance.
 
         Parameters:
-        * host: the hostname or IP-address of Paperless as string.
+        * host: the hostname or IP-address of Paperless as string, or yarl.URL object.
         * token: provide an api token created in Paperless Django settings.
         * session: provide an existing aiohttp ClientSession.
         """
-        self._host = host
+        # reverse compatibility, fall back to https
+        if isinstance(url, str) and not url.startswith("http"):
+            url = f"https://{url}"
+        url = URL(url)
+
+        # scheme check. fall back to https
+        if url.scheme not in ("https", "http"):
+            url = URL(url).with_scheme("https")
+
+        # check if /api is included
+        if url.name != "api":
+            url = URL(url).with_name("api")
+
+        self._url = url
         self._token = token
         self._request_opts = request_opts
         self._session = session
         self._initialized = False
-        self.logger = logging.getLogger(f"{__package__}[{host}]")
+        self.logger = logging.getLogger(f"{__package__}[{self._url.host}]")
 
         # endpoints
         self._consumption_templates: ConsumptionTemplatesController | None = None
@@ -69,9 +83,9 @@ class Paperless:  # pylint: disable=too-many-instance-attributes
         self._users: UsersController | None = None
 
     @property
-    def host(self) -> str | None:
-        """Return the hostname of Paperless."""
-        return self._host
+    def url(self) -> URL:
+        """Return the url of Paperless."""
+        return self._url
 
     @property
     def is_initialized(self) -> bool:
@@ -152,7 +166,7 @@ class Paperless:  # pylint: disable=too-many-instance-attributes
         """Initialize the connection to the api and fetch the endpoints."""
         self.logger.info("Fetching api endpoints.")
 
-        res = await self.request_json("get", "")
+        res = await self.request_json("get", f"{self._url}")
 
         self._consumption_templates = ConsumptionTemplatesController(
             self, res.pop(ResourceType.CONSUMPTION_TEMPLATES)
@@ -194,8 +208,7 @@ class Paperless:  # pylint: disable=too-many-instance-attributes
         if not isinstance(self._session, aiohttp.ClientSession):
             self._session = aiohttp.ClientSession()
 
-        url = path if path.startswith("http") else f"http://{self.host}/api/{path}"
-        url = url.rstrip("/") + "/"  # check and add trailing slash
+        path = path.rstrip("/") + "/"  # check and add trailing slash
 
         if isinstance(self._request_opts, dict):
             kwargs.update(self._request_opts)
@@ -208,7 +221,7 @@ class Paperless:  # pylint: disable=too-many-instance-attributes
             }
         )
 
-        async with self._session.request(method, url, **kwargs) as res:
+        async with self._session.request(method, path, **kwargs) as res:
             yield res
 
     async def request_json(

--- a/pypaperless/__init__.py
+++ b/pypaperless/__init__.py
@@ -26,6 +26,7 @@ from .controllers import (
 )
 from .errors import BadRequestException, DataNotExpectedException
 from .models.shared import ResourceType
+from .util import create_url_from_input
 
 
 class Paperless:  # pylint: disable=too-many-instance-attributes
@@ -46,20 +47,7 @@ class Paperless:  # pylint: disable=too-many-instance-attributes
         * token: provide an api token created in Paperless Django settings.
         * session: provide an existing aiohttp ClientSession.
         """
-        # reverse compatibility, fall back to https
-        if isinstance(url, str) and not url.startswith("http"):
-            url = f"https://{url}"
-        url = URL(url)
-
-        # scheme check. fall back to https
-        if url.scheme not in ("https", "http"):
-            url = URL(url).with_scheme("https")
-
-        # check if /api is included
-        if url.name != "api":
-            url = URL(url).with_name("api")
-
-        self._url = url
+        self._url = create_url_from_input(url)
         self._token = token
         self._request_opts = request_opts
         self._session = session

--- a/pypaperless/util.py
+++ b/pypaperless/util.py
@@ -21,6 +21,26 @@ from enum import Enum
 from types import NoneType, UnionType
 from typing import Any, Union, get_args, get_origin, get_type_hints
 
+from yarl import URL
+
+
+def create_url_from_input(url: str | URL) -> URL:
+    """Create URL from string or URL and prepare for further usage."""
+    # reverse compatibility, fall back to https
+    if isinstance(url, str) and not url.startswith("http"):
+        url = f"https://{url}"
+    url = URL(url)
+
+    # scheme check. fall back to https
+    if url.scheme not in ("https", "http"):
+        url = URL(url).with_scheme("https")
+
+    # check if /api is included
+    if url.name != "api":
+        url = url.with_path(url.path.rstrip("/") + "/api")
+
+    return url
+
 
 def update_dataclass(cur_obj: dataclass, new_vals: dict) -> set[str]:
     """

--- a/pypaperless/util.py
+++ b/pypaperless/util.py
@@ -28,7 +28,7 @@ def create_url_from_input(url: str | URL) -> URL:
     """Create URL from string or URL and prepare for further usage."""
     # reverse compatibility, fall back to https
     if isinstance(url, str) and not url.startswith("http"):
-        url = f"https://{url}"
+        url = f"https://{url}".rstrip("/")
     url = URL(url)
 
     # scheme check. fall back to https

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3"
 ]
 dependencies = [
-    "aiohttp"
+    "aiohttp==3.9.1",
+    "yarl==1.9.4"
 ]
 
 [project.urls]

--- a/tests/api/test_general.py
+++ b/tests/api/test_general.py
@@ -107,7 +107,9 @@ async def test_dataclass_conversion():
 
 async def test_paperless(paperless: Paperless, data):
     """Test Paperless object."""
-    assert paperless.host == "local.test:1337"
+    assert paperless.url.host == "local.test"
+    assert paperless.url.port == 1337
+    assert paperless.url.name == "api"
     assert paperless.is_initialized
 
     # okay, lets make a real request

--- a/tests/api/test_general.py
+++ b/tests/api/test_general.py
@@ -153,6 +153,14 @@ async def test_url_creation():
     url = create_url_from_input("http://hostname")
     assert url.port == 80
 
+    # should be https even on just setting a port number
+    url = create_url_from_input("hostname:80")
+    assert url.scheme == "https"
+
+    # test api/api url
+    url = create_url_from_input("hostname/api/api/")
+    assert f"{url}" == "https://hostname/api/api"
+
     # test with path and check if "api" is added
     url = create_url_from_input("hostname/path/to/paperless")
     assert f"{url}" == "https://hostname/path/to/paperless/api"

--- a/tests/api/test_general.py
+++ b/tests/api/test_general.py
@@ -6,7 +6,12 @@ from enum import Enum
 from unittest.mock import patch
 
 from pypaperless import Paperless
-from pypaperless.util import dataclass_from_dict, dataclass_to_dict, update_dataclass
+from pypaperless.util import (
+    create_url_from_input,
+    dataclass_from_dict,
+    dataclass_to_dict,
+    update_dataclass,
+)
 
 
 async def test_dataclass_conversion():
@@ -109,7 +114,6 @@ async def test_paperless(paperless: Paperless, data):
     """Test Paperless object."""
     assert paperless.url.host == "local.test"
     assert paperless.url.port == 1337
-    assert paperless.url.name == "api"
     assert paperless.is_initialized
 
     # okay, lets make a real request
@@ -130,3 +134,25 @@ async def test_paperless(paperless: Paperless, data):
     with patch.object(paperless2, "request_json", return_value=data["endpoints"]):
         async with paperless2:
             assert paperless2.is_initialized
+
+
+async def test_url_creation():
+    """Test url creation."""
+    # test default ssl
+    url = create_url_from_input("hostname")
+    assert url.host == "hostname"
+    assert url.port == 443
+
+    # test if api-path is added
+    assert url.name == "api"
+
+    # test full url string
+    assert f"{url}" == "https://hostname/api"
+
+    # test enforce http
+    url = create_url_from_input("http://hostname")
+    assert url.port == 80
+
+    # test with path and check if "api" is added
+    url = create_url_from_input("hostname/path/to/paperless")
+    assert f"{url}" == "https://hostname/path/to/paperless/api"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ async def paperless() -> Paperless:
         d = load_fixture_data("data.json")
         return d["endpoints"]
 
-    api = Paperless("http://local.test:1337", "secret-key")
+    api = Paperless("http://local.test:1337", "secret-key", request_opts={"ssl": False})
 
     with patch.object(api, "request_json", return_value=endpoints_data()):
         await api.initialize()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ async def paperless() -> Paperless:
         d = load_fixture_data("data.json")
         return d["endpoints"]
 
-    api = Paperless("local.test:1337", "secret-key")
+    api = Paperless("http://local.test:1337", "secret-key")
 
     with patch.object(api, "request_json", return_value=endpoints_data()):
         await api.initialize()


### PR DESCRIPTION
There was a relic in the code from the beginning of the project, which should be solved now. PyPaperless now utilizes yarl, which was already a sub dependency.

Before merge, we have little more work:
* Update documentation
* ~~Update toml to add the yarl dependency~~
* Move new logic into a helper function (for tests)

Solves #49.