### PR TITLE
Feature Request: maintain custom fields at a document

### DIFF
--- a/pypaperless/controllers/base.py
+++ b/pypaperless/controllers/base.py
@@ -174,7 +174,7 @@ class DeleteMixin(BaseControllerProtocol[ResourceT]):
             raise exc
 
 
-class BaseService:
+class BaseService:  # pylint: disable=too-few-public-methods
     """Handle requests to sub-endpoints or special tasks."""
 
     def __init__(self, controller: BaseController) -> None:
@@ -183,13 +183,3 @@ class BaseService:
         self._controller = controller
         self._path = controller.path
         self._logger = controller._logger
-
-    @property
-    def controller(self) -> BaseController:
-        """Get the controller."""
-        return self._controller
-
-    @property
-    def path(self) -> str:
-        """Return the url path."""
-        return self._path

--- a/tests/test_paperless_0_0_0.py
+++ b/tests/test_paperless_0_0_0.py
@@ -46,11 +46,9 @@ class TestBeginPaperless:
 
     async def test_init(self, api_00: Paperless):
         """Test init."""
-        assert api_00._url
         assert api_00._token
         assert api_00._request_opts
         assert not api_00._session
-        assert api_00._initialized
         # test properties
         assert api_00.url
         assert api_00.is_initialized

--- a/tests/test_paperless_1_17_0.py
+++ b/tests/test_paperless_1_17_0.py
@@ -13,11 +13,9 @@ class TestBeginPaperless:
 
     async def test_init(self, api_117: Paperless):
         """Test init."""
-        assert api_117._url
         assert api_117._token
         assert api_117._request_opts
         assert not api_117._session
-        assert api_117._initialized
         # test properties
         assert api_117.url
         assert api_117.is_initialized

--- a/tests/test_paperless_1_8_0.py
+++ b/tests/test_paperless_1_8_0.py
@@ -16,11 +16,12 @@ class TestBeginPaperless:
 
     async def test_init(self, api_18: Paperless):
         """Test init."""
-        assert api_18._url
         assert api_18._token
         assert api_18._request_opts
         assert not api_18._session
-        assert api_18._initialized
+        # test properties
+        assert api_18.url
+        assert api_18.is_initialized
 
     async def test_features(self, api_18: Paperless):
         """Test features."""

--- a/tests/test_paperless_2_0_0.py
+++ b/tests/test_paperless_2_0_0.py
@@ -203,6 +203,9 @@ class TestCustomFieldValues:
         assert isinstance(document.custom_fields, list)
         for item in document.custom_fields:
             assert isinstance(item, CustomFieldValue)
+        # must raise as 1337 doesn't exist
+        with pytest.raises(HTTPNotFound):
+            await api_20.documents.custom_fields(1337, fields)
 
 
 class TestShareLinks:

--- a/tests/test_paperless_2_0_0.py
+++ b/tests/test_paperless_2_0_0.py
@@ -17,10 +17,11 @@ from pypaperless.models import (
     ConsumptionTemplate,
     CustomField,
     CustomFieldPost,
+    Document,
     ShareLink,
     ShareLinkPost,
 )
-from pypaperless.models.custom_fields import CustomFieldType
+from pypaperless.models.custom_fields import CustomFieldType, CustomFieldValue
 from pypaperless.models.share_links import ShareLinkFileVersion
 
 
@@ -29,11 +30,9 @@ class TestBeginPaperless:
 
     async def test_init(self, api_20: Paperless):
         """Test init."""
-        assert api_20._url
         assert api_20._token
         assert api_20._request_opts
         assert not api_20._session
-        assert api_20._initialized
         # test properties
         assert api_20.url
         assert api_20.is_initialized
@@ -183,6 +182,27 @@ class TestCustomFields:
         # must raise as we deleted 9
         with pytest.raises(HTTPNotFound):
             await api_20.custom_fields.one(9)
+
+
+class TestCustomFieldValues:
+    """Custom Field Values test cases."""
+
+    async def test_set(self, api_20: Paperless):
+        """Test set."""
+        document = await api_20.documents.one(2)
+        assert isinstance(document, Document)
+        assert isinstance(document.custom_fields, list)
+        assert len(document.custom_fields) > 0
+        for item in document.custom_fields:
+            assert isinstance(item, CustomFieldValue)
+        # manipulate custom fields
+        fields = document.custom_fields
+        new_field = CustomFieldValue(field=1, value=False)
+        fields.append(new_field)
+        document = await api_20.documents.custom_fields(document, fields)
+        assert isinstance(document.custom_fields, list)
+        for item in document.custom_fields:
+            assert isinstance(item, CustomFieldValue)
 
 
 class TestShareLinks:

--- a/tests/test_paperless_2_3_0.py
+++ b/tests/test_paperless_2_3_0.py
@@ -24,11 +24,9 @@ class TestBeginPaperless:
 
     async def test_init(self, api_23: Paperless):
         """Test init."""
-        assert api_23._url
         assert api_23._token
         assert api_23._request_opts
         assert not api_23._session
-        assert api_23._initialized
         # test properties
         assert api_23.url
         assert api_23.is_initialized

--- a/tests/util/router.py
+++ b/tests/util/router.py
@@ -260,7 +260,7 @@ async def put_resource_item(req: Request, resource: str, item: int):
         if result["id"] == item:
             result = payload  # noqa: PLW2901
             return result
-    return HTTPNotFound()
+    raise HTTPNotFound()
 
 
 @FakePaperlessAPI.patch("/api/{resource}/{item:int}/")
@@ -273,7 +273,7 @@ async def patch_resource_item(req: Request, resource: str, item: int):
             for k, v in payload.items():
                 result[k] = v
             return result
-    return HTTPNotFound()
+    raise HTTPNotFound()
 
 
 @FakePaperlessAPI.delete("/api/{resource}/{item:int}/")
@@ -284,4 +284,4 @@ async def delete_resource_item(req: Request, resource: str, item: int):
         if result["id"] == item:
             data["results"].pop(idx)
             return Response(status_code=204)
-    return HTTPNotFound()
+    raise HTTPNotFound()

--- a/tests/util/router.py
+++ b/tests/util/router.py
@@ -263,6 +263,19 @@ async def put_resource_item(req: Request, resource: str, item: int):
     return HTTPNotFound()
 
 
+@FakePaperlessAPI.patch("/api/{resource}/{item:int}/")
+async def patch_resource_item(req: Request, resource: str, item: int):
+    """Patch resource item."""
+    payload = await req.json()
+    data = _api_switcher(req, resource.upper())
+    for result in data["results"]:
+        if result["id"] == item:
+            for k, v in payload.items():
+                result[k] = v
+            return result
+    return HTTPNotFound()
+
+
 @FakePaperlessAPI.delete("/api/{resource}/{item:int}/")
 async def delete_resource_item(req: Request, resource: str, item: int):
     """Delete resource item."""


### PR DESCRIPTION
Add custom fields service on the DocumentsController. The method accepts either a list of CustomFieldValues or empty list, and will persist that list on Paperless-ngx. Existing data gets overwritten.

Also added this fact to the documentation.

Resolves #54.