### PR TITLE
Fix date to str converison

### DIFF
--- a/pypaperless/models/utils/__init__.py
+++ b/pypaperless/models/utils/__init__.py
@@ -40,10 +40,7 @@ def _str_to_date(datestr: str):
 
 def _dateobj_to_str(value: date | datetime):
     """Parse string from date objects."""
-    result = value.isoformat().replace("+00:00", "Z")
-    if isinstance(value, datetime):
-        result = result.rstrip("Z") + "Z"
-    return result
+    return value.isoformat().replace("+00:00", "Z")
 
 
 def object_to_dict_value(value: Any) -> Any:


### PR DESCRIPTION
Resolves #113 

Datetime objects were serialized in a wrong format, so Paperless responded with a format error. This happened in timezones with a time delta >0.

