### PR TITLE
Add initialization error

### DIFF
--- a/src/pypaperless/exceptions.py
+++ b/src/pypaperless/exceptions.py
@@ -10,8 +10,8 @@ class PaperlessError(Exception):
 # Sessions and requests
 
 
-class AuthentificationRequiredError(PaperlessError):
-    """Raise when initializing a `Paperless` instance without url/token or session."""
+class InitializationError(PaperlessError):
+    """Raise when initializing a `Paperless` instance without valid url or token."""
 
 
 class BadJsonResponseError(PaperlessError):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,6 +13,7 @@ from pypaperless.const import API_PATH, PaperlessResource
 from pypaperless.exceptions import (
     BadJsonResponseError,
     DraftNotSupportedError,
+    InitializationError,
     JsonResponseWithError,
 )
 from pypaperless.models import Page
@@ -83,6 +84,26 @@ class TestPaperless:
         """Test availability of helpers against specific api version."""
         assert api_latest.custom_fields.is_available
         assert api_latest.workflows.is_available
+
+    async def test_init_error(self, resp: aioresponses, api: Paperless) -> None:
+        """Test initialization error."""
+        # http status error
+        resp.get(
+            f"{PAPERLESS_TEST_URL}{API_PATH['index']}",
+            status=401,
+            body="any html",
+        )
+        with pytest.raises(InitializationError):
+            await api.initialize()
+
+        # http ok, wrong payload
+        resp.get(
+            f"{PAPERLESS_TEST_URL}{API_PATH['index']}",
+            status=200,
+            body="any html",
+        )
+        with pytest.raises(InitializationError):
+            await api.initialize()
 
     async def test_jsonresponsewitherror(self) -> None:
         """Test JsonResponseWithError."""


### PR DESCRIPTION
pypaperless shall raise an InitializationError when got into trouble on initialization of the `Paperless` object.

It will raise when getting a HTTP error or when the first payload cannot json decoded, during initialization.