### PR TITLE
Fix permissions are not requested by pages()/reduce()

### DIFF
--- a/src/pypaperless/models/mixins/helpers/callable.py
+++ b/src/pypaperless/models/mixins/helpers/callable.py
@@ -2,8 +2,6 @@
 
 from pypaperless.models.base import HelperProtocol, ResourceT
 
-from .securable import SecurableMixin
-
 
 class CallableMixin(HelperProtocol[ResourceT]):
     """Provide methods for calling a specific resource item."""
@@ -33,7 +31,7 @@ class CallableMixin(HelperProtocol[ResourceT]):
         item = self._resource_cls.create_with_data(self._api, data)
 
         # set requesting full permissions
-        if SecurableMixin in type(self).__bases__ and getattr(self, "_request_full_perms", False):
+        if getattr(self, "_request_full_perms", False):
             item._params.update({"full_perms": "true"})  # noqa: SLF001
 
         if not lazy:

--- a/src/pypaperless/models/mixins/helpers/iterable.py
+++ b/src/pypaperless/models/mixins/helpers/iterable.py
@@ -94,4 +94,8 @@ class IterableMixin(HelperProtocol[ResourceT]):
         params.setdefault("page", page)
         params.setdefault("page_size", page_size)
 
+        # set requesting full permissions
+        if getattr(self, "_request_full_perms", False):
+            params.update({"full_perms": "true"})
+
         return PageGenerator(self._api, self._api_path, self._resource_cls, params=params)


### PR DESCRIPTION
`pypaperless` didn't request object permissions when using the IterableMixin, as it did when using the CallableMixin.

Solves #161.