### PR TITLE
Add Task status for STARTED

### DIFF
--- a/src/pypaperless/models/common.py
+++ b/src/pypaperless/models/common.py
@@ -192,6 +192,7 @@ class TaskStatusType(Enum):
     """Represent a subtype of `Task`."""
 
     PENDING = "PENDING"
+    STARTED = "STARTED"
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
     UNKNOWN = "UNKNOWN"


### PR DESCRIPTION
Tasks that have been started can now be represented as TaskStatusType.STARTED, where previously they'd be rendered as UNKNOWN.