### PR TITLE
Add `extra_data` to `CustomFieldDraft`

### DIFF
--- a/pypaperless/models/custom_fields.py
+++ b/pypaperless/models/custom_fields.py
@@ -49,6 +49,7 @@ class CustomFieldDraft(
 
     name: str | None = None
     data_type: CustomFieldType | None = None
+    extra_data: dict[str, Any] | None = None
 
 
 class CustomFieldHelper(


### PR DESCRIPTION
closes https://github.com/tb1337/paperless-api/issues/374

Additionally this `extra_data` is important for adding `monetary` fields:
```
extra_data = {
    "default_currency": "EUR"
}
```