### PR TITLE
Make `CustomField.extra_data` a typed dict

### DIFF
--- a/pypaperless/models/common.py
+++ b/pypaperless/models/common.py
@@ -4,7 +4,7 @@ import contextlib
 import datetime
 from dataclasses import dataclass, field
 from enum import Enum, StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
     from pypaperless import Paperless
@@ -14,6 +14,20 @@ if TYPE_CHECKING:
 
 
 # custom_fields
+class CustomFieldExtraDataSelectOptions(TypedDict):
+    """Represent the `extra_data.select_options` field of a `CustomField`."""
+
+    id: str | None
+    label: str | None
+
+
+class CustomFieldExtraData(TypedDict):
+    """Represent the `extra_data` field of a `CustomField`."""
+
+    default_currency: str | None
+    select_options: list[CustomFieldExtraDataSelectOptions | None]
+
+
 class CustomFieldType(Enum):
     """Represent a subtype of `CustomField`."""
 
@@ -43,7 +57,7 @@ class CustomFieldValue:
     value: Any | None = None
     name: str | None = None
     data_type: CustomFieldType | None = None
-    extra_data: dict[str, Any] | None = None
+    extra_data: CustomFieldExtraData | None = None
 
 
 @dataclass(kw_only=True)
@@ -94,19 +108,17 @@ class CustomFieldSelectValue(CustomFieldValue):
     value: int | None = None
 
     @property
-    def labels(self) -> list[dict[str, str]]:
+    def labels(self) -> list[CustomFieldExtraDataSelectOptions | None]:
         """Return the list of labels of the `CustomField`."""
-        try:
-            # this is currently intended
-            return self.extra_data["select_options"]  # type: ignore[no-any-return, index]
-        except (KeyError, TypeError):
+        if not self.extra_data:
             return []
+        return self.extra_data["select_options"]
 
     @property
     def label(self) -> str | None:
         """Return the label for `value` or fall back to `None`."""
         for opt in self.labels:
-            if opt["id"] == self.value:
+            if opt and opt["id"] == self.value:
                 return opt["label"]
         return None
 

--- a/pypaperless/models/custom_fields.py
+++ b/pypaperless/models/custom_fields.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from pypaperless.const import API_PATH, PaperlessResource
 
 from .base import HelperBase, PaperlessModel
-from .common import CustomFieldType
+from .common import CustomFieldExtraData, CustomFieldType
 from .mixins import helpers, models
 
 if TYPE_CHECKING:
@@ -26,7 +26,7 @@ class CustomField(
     id: int
     name: str | None = None
     data_type: CustomFieldType | None = None
-    extra_data: dict[str, Any] | None = None
+    extra_data: CustomFieldExtraData | None = None
     document_count: int | None = None
 
     def __init__(self, api: "Paperless", data: dict[str, Any]) -> None:
@@ -49,6 +49,7 @@ class CustomFieldDraft(
 
     name: str | None = None
     data_type: CustomFieldType | None = None
+    extra_data: CustomFieldExtraData | None = None
 
 
 class CustomFieldHelper(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,6 @@ dev = [
 "Bug Reports" = "https://github.com/tb1337/paperless-api/issues"
 "Coverage" = "https://codecov.io/gh/tb1337/paperless-api"
 
-[tool.setuptools]
-include-package-data = true
-
-[tool.setuptools.packages.find]
-include = ["pypaperless*"]
-
 [tool.coverage.run]
 plugins = ["covdefaults"]
 source = ["pypaperless"]


### PR DESCRIPTION
I want to improve working with `CustomField.extra_data` but still handle it as a normal dict, as it isn't important enough to be a dataclass, but still needed especially when parsing custom_field data or creating new custom fields in Paperless-ngx.

* Make `extra_data` a TypedDict
* Add TypedDict handling to `dict_value_to_object` and `object_to_dict_value`
* Add tests

Closes #374 