### PR TITLE
removed header update on session

### DIFF
--- a/pypaperless/api.py
+++ b/pypaperless/api.py
@@ -311,12 +311,16 @@ class Paperless:
             self._session = aiohttp.ClientSession()
 
         # add headers
-        self._session.headers.update(
-            {
-                "Accept": f"application/json; version={API_VERSION}",
-                "Authorization": f"Token {self._token}",
-            }
-        )
+        headers = {
+            "Accept": f"application/json; version={API_VERSION}",
+            "Authorization": f"Token {self._token}",
+        }
+
+        # Merge with any user-defined headers (optional)
+        if "headers" in kwargs:
+            kwargs["headers"].update(headers)
+        else:
+            kwargs["headers"] = headers
 
         # add request args
         kwargs.update(self._request_args)


### PR DESCRIPTION
I updated the way headers are handled to avoid the issue caused by trying to update a mappingproxy object. In Python, mappingproxy objects are immutable, meaning you cannot modify them directly using methods like update(). To resolve this, I switched to an approach where the headers are merged with custom ones or set to default headers, without trying to update the mappingproxy object directly.
This caused errors when passing in a custom session.