### PR TITLE
Add remote version endpoint

### DIFF
--- a/pypaperless/api.py
+++ b/pypaperless/api.py
@@ -33,6 +33,7 @@ class Paperless:
         (PaperlessResource.SAVED_VIEWS, helpers.SavedViewHelper),
         (PaperlessResource.SHARE_LINKS, helpers.ShareLinkHelper),
         (PaperlessResource.STATISTICS, helpers.StatisticHelper),
+        (PaperlessResource.REMOTE_VERSION, helpers.RemoteVersionHelper),
         (PaperlessResource.STATUS, helpers.StatusHelper),
         (PaperlessResource.STORAGE_PATHS, helpers.StoragePathHelper),
         (PaperlessResource.TAGS, helpers.TagHelper),
@@ -52,6 +53,7 @@ class Paperless:
     saved_views: helpers.SavedViewHelper
     share_links: helpers.ShareLinkHelper
     statistics: helpers.StatisticHelper
+    remote_version: helpers.RemoteVersionHelper
     status: helpers.StatusHelper
     storage_paths: helpers.StoragePathHelper
     tags: helpers.TagHelper

--- a/pypaperless/const.py
+++ b/pypaperless/const.py
@@ -19,6 +19,7 @@ MAIL_RULES = "mail_rules"
 SAVED_VIEWS = "saved_views"
 SHARE_LINKS = "share_links"
 STATISTICS = "statistics"
+REMOTE_VERSION = "remote_version"
 STATUS = "status"
 STORAGE_PATHS = "storage_paths"
 TAGS = "tags"
@@ -62,6 +63,7 @@ API_PATH = {
     f"{SHARE_LINKS}": f"/api/{SHARE_LINKS}/",
     f"{SHARE_LINKS}_single": f"/api/{SHARE_LINKS}/{{pk}}/",
     f"{STATISTICS}": f"/api/{STATISTICS}/",
+    f"{REMOTE_VERSION}": f"/api/{REMOTE_VERSION}/",
     f"{STATUS}": f"/api/{STATUS}/",
     f"{STORAGE_PATHS}": f"/api/{STORAGE_PATHS}/",
     f"{STORAGE_PATHS}_single": f"/api/{STORAGE_PATHS}/{{pk}}/",
@@ -96,6 +98,7 @@ class PaperlessResource(StrEnum):
     SAVED_VIEWS = SAVED_VIEWS
     SHARE_LINKS = SHARE_LINKS
     STATISTICS = STATISTICS
+    REMOTE_VERSION = REMOTE_VERSION
     STATUS = STATUS
     STORAGE_PATHS = STORAGE_PATHS
     TAGS = TAGS

--- a/pypaperless/helpers.py
+++ b/pypaperless/helpers.py
@@ -14,6 +14,7 @@ from .models.custom_fields import CustomFieldHelper  # noqa: F401
 from .models.documents import DocumentHelper, DocumentMetaHelper, DocumentNoteHelper  # noqa: F401
 from .models.mails import MailAccountHelper, MailRuleHelper  # noqa: F401
 from .models.permissions import GroupHelper, UserHelper  # noqa: F401
+from .models.remote_version import RemoteVersionHelper  # noqa: F401
 from .models.saved_views import SavedViewHelper  # noqa: F401
 from .models.share_links import ShareLinkHelper  # noqa: F401
 from .models.statistics import StatisticHelper  # noqa: F401

--- a/pypaperless/models/__init__.py
+++ b/pypaperless/models/__init__.py
@@ -22,6 +22,7 @@ from .documents import (
 from .mails import MailAccount, MailRule
 from .pages import Page
 from .permissions import Group, User
+from .remote_version import RemoteVersion
 from .saved_views import SavedView
 from .share_links import ShareLink, ShareLinkDraft
 from .statistics import Statistic
@@ -46,6 +47,7 @@ __all__ = (
     "MailAccount",
     "MailRule",
     "Page",
+    "RemoteVersion",
     "SavedView",
     "ShareLink",
     "ShareLinkDraft",

--- a/pypaperless/models/remote_version.py
+++ b/pypaperless/models/remote_version.py
@@ -1,0 +1,33 @@
+"""Provide `Remote Version` related models and helpers."""
+
+from dataclasses import dataclass
+
+from pypaperless.const import API_PATH, PaperlessResource
+
+from .base import HelperBase, PaperlessModel
+
+
+@dataclass(init=False)
+class RemoteVersion(
+    PaperlessModel,
+):
+    """Represent Paperless `Remote Version`."""
+
+    _api_path = API_PATH["remote_version"]
+
+    version: str | None = None
+    update_available: bool | None = None
+
+
+class RemoteVersionHelper(HelperBase[RemoteVersion]):
+    """Represent a factory for Paperless `Remote Version` models."""
+
+    _api_path = API_PATH["remote_version"]
+    _resource = PaperlessResource.REMOTE_VERSION
+
+    _resource_cls = RemoteVersion
+
+    async def __call__(self) -> RemoteVersion:
+        """Request the `Remote Version` model data."""
+        res = await self._api.request_json("get", self._api_path)
+        return self._resource_cls.create_with_data(self._api, res, fetched=True)

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -15,6 +15,7 @@ from .v0_0_0 import (
     V0_0_0_MAIL_RULES,
     V0_0_0_OBJECT_PERMISSIONS,
     V0_0_0_PATHS,
+    V0_0_0_REMOTE_VERSION,
     V0_0_0_SAVED_VIEWS,
     V0_0_0_TAGS,
     V0_0_0_TASKS,
@@ -71,6 +72,7 @@ PATCHWORK = {
     "tasks": V0_0_0_TASKS,
     "token": V0_0_0_TOKEN,
     "users": V0_0_0_USERS,
+    "remote_version": V0_0_0_REMOTE_VERSION,
     # 1.8.0
     "storage_paths": V1_8_0_STORAGE_PATHS,
     # 1.17.0

--- a/tests/data/v0_0_0.py
+++ b/tests/data/v0_0_0.py
@@ -4,6 +4,8 @@
 
 from tests.const import PAPERLESS_TEST_TOKEN, PAPERLESS_TEST_URL
 
+V0_0_0_REMOTE_VERSION = {"version": "v2.15.3", "update_available": True}
+
 V0_0_0_TOKEN = {"token": PAPERLESS_TEST_TOKEN}
 
 V0_0_0_PATHS = {

--- a/tests/test_models_specific.py
+++ b/tests/test_models_specific.py
@@ -382,7 +382,7 @@ class TestModelDocuments:
         assert item.custom_fields.default(-1337) is None
 
 
-# test models/version.py
+# test models/remote_version.py
 class TestModelVersion:
     """Version test cases."""
 

--- a/tests/test_models_specific.py
+++ b/tests/test_models_specific.py
@@ -382,6 +382,23 @@ class TestModelDocuments:
         assert item.custom_fields.default(-1337) is None
 
 
+# test models/version.py
+class TestModelVersion:
+    """Version test cases."""
+
+    async def test_call(self, resp: aioresponses, api_latest: Paperless) -> None:
+        """Test call."""
+        resp.get(
+            f"{PAPERLESS_TEST_URL}{API_PATH['remote_version']}",
+            status=200,
+            payload=PATCHWORK["remote_version"],
+        )
+        remote_version = await api_latest.remote_version()
+        assert remote_version
+        assert isinstance(remote_version.version, str)
+        assert isinstance(remote_version.update_available, bool)
+
+
 # test models/statistics.py
 class TestModelStatistics:
     """Statistics test cases."""


### PR DESCRIPTION
Added /api/remote_version endpoint.
I'm not sure when the endpoint was added, but it's been around for a while. I just put it under 0.0.0 for now.

Edit: I know the version is already in the status and api, but the endpoint isn’t protected and also returns whether an update is available. It could be used to check if paperless can be reached.