### PR TITLE
Add errors for bad authentication

### DIFF
--- a/pypaperless/api.py
+++ b/pypaperless/api.py
@@ -242,7 +242,7 @@ class Paperless:
             try:
                 async with self.request("get", API_PATH["api_schema"]) as res:
                     res.raise_for_status()
-            except (PaperlessError, aiohttp.ClientError):
+            except aiohttp.ClientError:
                 return False
 
             self._version = res.headers.get("x-version", None)

--- a/pypaperless/api.py
+++ b/pypaperless/api.py
@@ -18,7 +18,6 @@ from .exceptions import (
     InitializationError,
     JsonResponseWithError,
     PaperlessConnectionError,
-    PaperlessError,
     PaperlessForbiddenError,
     PaperlessInactiveOrDeletedError,
     PaperlessInvalidTokenError,

--- a/pypaperless/api.py
+++ b/pypaperless/api.py
@@ -351,14 +351,19 @@ class Paperless:
         )
         self.logger.debug("%s (%d): %s", method.upper(), res.status, res.url)
 
+        # error handling for 401 and 403 codes
         if res.status == 401:
-            error_data = await res.json()
-            detail = error_data.get("detail", "")
+            try:
+                error_data = await res.json()
+                detail = error_data.get("detail", "")
+            except JSONDecodeError:
+                detail = ""
 
             if "inactive" in detail.lower() or "deleted" in detail.lower():
                 raise PaperlessInactiveOrDeletedError(res)
-            else:
-                raise PaperlessInvalidTokenError(res)
+
+            raise PaperlessInvalidTokenError(res)
+
         if res.status == 403:
             raise PaperlessForbiddenError(res)
 

--- a/pypaperless/exceptions.py
+++ b/pypaperless/exceptions.py
@@ -14,7 +14,11 @@ class InitializationError(PaperlessError):
     """Raise when initializing a `Paperless` instance without valid url or token."""
 
 
-class PaperlessAuthError(PaperlessError):
+class PaperlessConnectionError(InitializationError, PaperlessError):
+    """Raise when connection to Paperless is not possible."""
+
+
+class PaperlessAuthError(InitializationError, PaperlessError):
     """Raise when response is 401 code."""
 
 
@@ -26,7 +30,7 @@ class PaperlessInactiveOrDeletedError(PaperlessAuthError):
     """Raise when response is 401 code due user is inactive or deleted."""
 
 
-class PaperlessForbiddenError(PaperlessError):
+class PaperlessForbiddenError(InitializationError, PaperlessError):
     """Raise when response is 403 code."""
 
 

--- a/pypaperless/exceptions.py
+++ b/pypaperless/exceptions.py
@@ -14,6 +14,22 @@ class InitializationError(PaperlessError):
     """Raise when initializing a `Paperless` instance without valid url or token."""
 
 
+class PaperlessAuthError(PaperlessError):
+    """Raise when response is 401 code."""
+
+
+class PaperlessInvalidTokenError(PaperlessAuthError):
+    """Raise when response is 401 due invalid access token."""
+
+
+class PaperlessInactiveOrDeletedError(PaperlessAuthError):
+    """Raise when response is 401 code due user is inactive or deleted."""
+
+
+class PaperlessForbiddenError(PaperlessError):
+    """Raise when response is 403 code."""
+
+
 class BadJsonResponseError(PaperlessError):
     """Raise when response is no valid json."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,12 @@ async def api_version_00_fixture(
 ) -> AsyncGenerator[Paperless, Any]:
     """Return a basic Paperless object."""
     resp.get(
+        f"{PAPERLESS_TEST_URL}{API_PATH['api_schema']}",
+        status=500,
+        headers={"X-Version": "0.0.0"},
+        payload=PATCHWORK["paths_v0_0_0"],
+    )
+    resp.get(
         f"{PAPERLESS_TEST_URL}{API_PATH['index']}",
         status=200,
         headers={"X-Version": "0.0.0"},

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, fields
 from datetime import date, datetime
 from enum import Enum
 from typing import TypedDict
-from unittest.mock import patch
 
 import aiohttp
 import pytest
@@ -160,6 +159,19 @@ class TestPaperless:
         )
         with pytest.raises(InitializationError):
             await api.initialize()
+
+    @pytest.mark.parametrize(
+        "exception_cls",
+        [
+            PaperlessConnectionError,
+            PaperlessInvalidTokenError,
+            PaperlessInactiveOrDeletedError,
+            PaperlessForbiddenError,
+        ],
+    )
+    async def test_errors_are_backwards_compatible(self, exception_cls: type) -> None:
+        """Test, if new errors are backwards compatible."""
+        assert issubclass(exception_cls, InitializationError)
 
     async def test_jsonresponsewitherror(self) -> None:
         """Test JsonResponseWithError."""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -64,6 +64,11 @@ class TestPaperless:
     async def test_context(self, resp: aioresponses, api: Paperless) -> None:
         """Test context."""
         resp.get(
+            f"{PAPERLESS_TEST_URL}{API_PATH['api_schema']}",
+            status=500,
+            payload=PATCHWORK["paths"],
+        )
+        resp.get(
             f"{PAPERLESS_TEST_URL}{API_PATH['index']}",
             status=200,
             payload=PATCHWORK["paths"],
@@ -95,6 +100,11 @@ class TestPaperless:
         """Test initialization error."""
         # http status error
         resp.get(
+            f"{PAPERLESS_TEST_URL}{API_PATH['api_schema']}",
+            status=500,
+            payload=PATCHWORK["paths"],
+        )
+        resp.get(
             f"{PAPERLESS_TEST_URL}{API_PATH['index']}",
             status=401,
             body="any html",
@@ -104,6 +114,11 @@ class TestPaperless:
 
         # http status forbidden
         resp.get(
+            f"{PAPERLESS_TEST_URL}{API_PATH['api_schema']}",
+            status=500,
+            payload=PATCHWORK["paths"],
+        )
+        resp.get(
             f"{PAPERLESS_TEST_URL}{API_PATH['index']}",
             status=403,
             body="any html",
@@ -112,6 +127,11 @@ class TestPaperless:
             await api.initialize()
 
         # http ok, wrong payload
+        resp.get(
+            f"{PAPERLESS_TEST_URL}{API_PATH['api_schema']}",
+            status=500,
+            payload=PATCHWORK["paths"],
+        )
         resp.get(
             f"{PAPERLESS_TEST_URL}{API_PATH['index']}",
             status=200,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -16,6 +16,8 @@ from pypaperless.exceptions import (
     DraftNotSupportedError,
     InitializationError,
     JsonResponseWithError,
+    PaperlessForbiddenError,
+    PaperlessInvalidTokenError,
 )
 from pypaperless.models import Page
 from pypaperless.models.base import HelperBase, PaperlessModel
@@ -97,7 +99,16 @@ class TestPaperless:
             status=401,
             body="any html",
         )
-        with pytest.raises(InitializationError):
+        with pytest.raises(PaperlessInvalidTokenError):
+            await api.initialize()
+
+        # http status forbidden
+        resp.get(
+            f"{PAPERLESS_TEST_URL}{API_PATH['index']}",
+            status=403,
+            body="any html",
+        )
+        with pytest.raises(PaperlessForbiddenError):
             await api.initialize()
 
         # http ok, wrong payload


### PR DESCRIPTION
Hey! :)
Another PR from me. I’ve added improved error handling to check whether a user has given an invalid token or is inactive or deleted.
Both cases are based on the auth error, if the specific errors isn't needed.

Previously, depending on the case, I had BaseJsonResponseErrors or ClientErrors, which had to be interpreted individually with inner error.