### PR TITLE
Unclosed response warning with aiohttp in openapi schema initialization

### DIFF
--- a/pypaperless/api.py
+++ b/pypaperless/api.py
@@ -249,6 +249,7 @@ class Paperless:
                 return False
 
             return True
+
         async def _init_with_legacy_response() -> dict[str, str]:
             """Connect to paperless and request the entity dictionary (DRF)."""
             async with self.request("get", API_PATH["index"]) as res:


### PR DESCRIPTION
**Description:**
When using pypaperless, I receive the following warning from asyncio/aiohttp regarding an unclosed response:
``` 
ERROR:asyncio:Unclosed response
client_response: <ClientResponse(https://.../api/schema/) [200 OK]>
...
```
I tracked it down to the function, where the response is not always fully read (the body is never consumed if an exception occurs or not needed). This causes aiohttp to log a warning about unclosed response objects. `_init_with_openapi_response`
**Proposed fix:**
Read the response body completely in all code paths, for example by adding `await res.read()` at the end of the `async with` block.

This will properly close the response and remove the warning.
Thank you!
