### PR TITLE
Remove trailing slash if no scheme given

### DIFF
--- a/pypaperless/api.py
+++ b/pypaperless/api.py
@@ -142,9 +142,11 @@ class Paperless:
     def _create_base_url(url: str | URL) -> URL:
         """Create URL from string or URL and prepare for further use."""
         # reverse compatibility, fall back to https
-        if isinstance(url, str) and "://" not in url:
-            url = f"https://{url}"
-        url = URL(url.rstrip("/"))
+        if isinstance(url, str):
+            if "://" not in url:
+                url = f"https://{url}"
+            url = url.rstrip("/")
+        url = URL(url)
 
         # scheme check. fall back to https
         if url.scheme not in ("https", "http"):

--- a/pypaperless/api.py
+++ b/pypaperless/api.py
@@ -143,8 +143,8 @@ class Paperless:
         """Create URL from string or URL and prepare for further use."""
         # reverse compatibility, fall back to https
         if isinstance(url, str) and "://" not in url:
-            url = f"https://{url}".rstrip("/")
-        url = URL(url)
+            url = f"https://{url}"
+        url = URL(url.rstrip("/"))
 
         # scheme check. fall back to https
         if url.scheme not in ("https", "http"):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -294,6 +294,10 @@ class TestPaperless:
         url = create_url("hostname/api/api/")
         assert f"{url}" == "https://hostname/api/api"
 
+        # test slashes
+        url = create_url("hostname/api/endpoint///")
+        assert f"{url}" == "https://hostname/api/endpoint"
+
     async def test_generate_api_token(self, resp: aioresponses, api: Paperless) -> None:
         """Test generate api token."""
         # test successful token creation


### PR DESCRIPTION
Hey, 
currently the trailing slash is only removed if no scheme is given.
We should remove the trailing slash generally.

So if a user enters https://yourdomain.com/ we also remove the slash.