### PR TITLE
Fix: Correct return code for delete notes endpoint

### DIFF
--- a/pypaperless/models/documents.py
+++ b/pypaperless/models/documents.py
@@ -264,7 +264,7 @@ class DocumentNote(PaperlessModel):
             "id": self.id,
         }
         async with self._api.request("delete", self._api_path, params=params) as res:
-            return res.status == 204
+            return res.status == 200
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
I think there is a small bug when deleting notes: we should test, if return code is 200 (not 204).
