### PR TITLE
fix parsing created date (fixes #482)

### DIFF
--- a/pypaperless/models/utils/__init__.py
+++ b/pypaperless/models/utils/__init__.py
@@ -34,7 +34,7 @@ def _str_to_datetime(datetimestr: str) -> datetime:
 
 def _str_to_date(datestr: str) -> date:
     """Parse date from string."""
-    return date.fromisoformat(datestr)
+    return datetime.fromisoformat(datestr).date()
 
 
 def _dateobj_to_str(value: date | datetime) -> str:


### PR DESCRIPTION
fix parsing created date (fixes #482)

`date.fromisoformat()` expects YYYY-MM-HH, but in some processing step before a date like `2024-06-28T00:00:00+00:00` is generated, so this fails.

`datetime.time.fromisoformat('2024-06-28T00:00:00+00:00')` fails with
`ValueError: Invalid isoformat string: '2024-06-28T00:00:00+00:00'`.

Using `datetime.fromisoformat(datestr).date()` accepts a longer string and cuts it down to a date, e.g.

```
>>> datetime.datetime.fromisoformat('2024-06-28T00:00:00+00:00').date()
datetime.date(2024, 6, 28)
```
