### PR TITLE
allow credentials by making the token optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Little asynchronous client for *Paperless-ngx*, written in Python. You should at
 ## Features
 
 - Depends on aiohttp, works in async environments.
-- Token authentication only. **No credentials.**
+- Token authentication preferred (credentials possible using a URL like https://user:pass@example.com)
 - Request single resource items.
 - Iterate over all resource items or request them page by page.
 - Create, update and delete resource items.

--- a/pypaperless/api.py
+++ b/pypaperless/api.py
@@ -80,7 +80,7 @@ class Paperless:
     def __init__(
         self,
         url: str | URL,
-        token: str,
+        token: str = None,
         *,
         session: aiohttp.ClientSession | None = None,
         request_args: dict[str, Any] | None = None,
@@ -317,8 +317,9 @@ class Paperless:
         # add headers
         headers = {
             "Accept": f"application/json; version={self._request_api_version}",
-            "Authorization": f"Token {self._token}",
         }
+        if self._token:
+            headers["Authorization"] = f"Token {self._token}"
 
         # Merge with any user-defined headers (optional)
         if "headers" in kwargs:


### PR DESCRIPTION
I'm using paperless-ngx behind a reverse proxy, that does user-based authentication. So I need to use credentials.

Technically it's a low hanging fruit: just make the token optional.
aiohttp accepts credentials as part of the URL like `https://user:pass@example.com`.

@tb1337 , I saw that you wrote "No credentials" in bold face - so is it a no-no for you? Or would you accept that PR?
I updated the README for completeness, but if you prefer, this could also stay a hidden feature.
