### PR TITLE
⚡ Optimize GitHub Actions to drastically reduce CI minutes

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,18 +10,21 @@ on:
       - "uv.lock"
       - "pypaperless/**"
       - "tests/**"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/linting.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   DEFAULT_PYTHON: "3.14"
 
 jobs:
   lint:
-    name: ${{ matrix.tool }}
+    name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tool: [codespell, ruff, prek-hooks, yamllint]
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v6.0.2
@@ -31,30 +34,17 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Set up uv
-        run: |
-          pipx install uv
-          uv venv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: 🏗 Install Python dependencies
         run: uv sync --group dev
-      - name: 🚀 Execute checks
+      - name: 🚀 Run ruff (with GitHub annotations)
         run: |
-          if [ "${{ matrix.tool }}" = "codespell" ]; then
-            uv run prek run codespell --all-files
-          elif [ "${{ matrix.tool }}" = "ruff" ]; then
-            uv run ruff check --output-format=github .
-            uv run ruff format --check .
-          elif [ "${{ matrix.tool }}" = "prek-hooks" ]; then
-            uv run prek run check-ast --all-files
-            uv run prek run check-case-conflict --all-files
-            uv run prek run check-docstring-first --all-files
-            uv run prek run check-json --all-files
-            uv run prek run check-merge-conflict --all-files
-            uv run prek run check-symlinks --all-files
-            uv run prek run check-toml --all-files
-            uv run prek run check-yaml --all-files
-            uv run prek run detect-private-key --all-files
-            uv run prek run end-of-file-fixer --all-files
-            uv run prek run trailing-whitespace --all-files
-          elif [ "${{ matrix.tool }}" = "yamllint" ]; then
-            uv run yamllint .
-          fi
+          uv run ruff check --output-format=github .
+          uv run ruff format --check .
+      - name: 🚀 Run remaining hooks via prek
+        env:
+          SKIP: mypy,pytest,ruff-check,ruff-format
+        run: uv run prek run --all-files --show-diff-on-failure

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,7 +4,7 @@ name: Lock
 # yamllint disable-line rule:truthy
 on:
   schedule:
-    - cron: "0 5 * * *"
+    - cron: "0 5 * * 1,3,5"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,10 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Set up uv
-        run: |
-          pipx install uv
-          uv venv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: 🏗 Install Python dependencies
         run: uv sync --group dev
       - name: 🏗 Set package version

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,7 +4,7 @@ name: Stale
 # yamllint disable-line rule:truthy
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 3 * * 1,3,5"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,13 +10,22 @@ on:
       - "uv.lock"
       - "pypaperless/**"
       - "tests/**"
+      - ".github/workflows/tests.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  COVERAGE_PYTHON: "3.14"
 
 jobs:
   pytest:
     name: Python ${{ matrix.python }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.13", "3.14"]
     steps:
@@ -28,31 +37,18 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: 🏗 Set up uv
-        run: |
-          pipx install uv
-          uv venv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: 🏗 Install Python dependencies
         run: uv sync --group dev
       - name: 🚀 Run pytest
         run: uv run pytest -v --cov-report xml:coverage.xml --cov pypaperless tests
-      - name: ⬆️ Upload coverage artifact
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: coverage-${{ matrix.python }}
-          path: coverage.xml
-
-  coverage:
-    runs-on: ubuntu-latest
-    needs: pytest
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-      - name: ⬇️ Download coverage data
-        uses: actions/download-artifact@v8.0.1
       - name: 🚀 Upload coverage report
+        if: matrix.python == env.COVERAGE_PYTHON
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -10,7 +10,12 @@ on:
       - "uv.lock"
       - "pypaperless/**"
       - "tests/**"
+      - ".github/workflows/typing.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   DEFAULT_PYTHON: "3.14"
@@ -28,9 +33,10 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Set up uv
-        run: |
-          pipx install uv
-          uv venv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: 🏗 Install Python dependencies
         run: uv sync --group dev
       - name: 🚀 Run mypy


### PR DESCRIPTION
- Use astral-sh/setup-uv with dependency cache across all workflows
- linting: drop 4-job matrix; run prek with SKIP for mypy/pytest in one job
- tests: merge coverage upload into pytest job (3.14 only), drop extra job
- tests/lint/typing: add concurrency to cancel superseded runs
- codecov: fail_ci_if_error=false to avoid flake-driven reruns
- stale/lock cron: daily -> Mon/Wed/Fri