### PR TITLE
Add find_duplicate() helper to skip uploads of known files

### DIFF
--- a/docs/concepts/documents.md
+++ b/docs/concepts/documents.md
@@ -274,6 +274,24 @@ print(f"Upload queued as task: {task_id}")
 !!! note
     Unlike other resources, `save()` for documents returns a **task ID string**, not an integer ID. The document is processed asynchronously by Paperless-ngx. Use `paperless.tasks` to monitor the task.
 
+### Skipping duplicates before upload
+
+Paperless-ngx rejects duplicate files server-side, but the consume task only fails *after* the file has been transferred and queued. For large files, or when you upload from a bulk script, it is cheaper to check up-front. `find_duplicate()` hashes the bytes (MD5, as used by Paperless) and asks the server whether a document with that checksum already exists:
+
+```python
+with open("invoice.pdf", "rb") as f:
+    content = f.read()
+
+existing = await paperless.documents.find_duplicate(content, filename="invoice.pdf")
+if existing is not None:
+    print(f"Already uploaded as #{existing.id}: {existing.title}")
+else:
+    draft = paperless.documents.create(document=content, filename="invoice.pdf")
+    await paperless.documents.save(draft)
+```
+
+`filename` is optional and, when given, additionally matches `original_filename` case-insensitively. The hash is computed in a worker thread so the event loop stays responsive on large files.
+
 ### Uploading with custom field values
 
 To set explicit values on custom fields at upload time, build a

--- a/pypaperless/services/documents/document.py
+++ b/pypaperless/services/documents/document.py
@@ -1,5 +1,7 @@
 """Provide `Document` related services."""
 
+import asyncio
+import hashlib
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Self, Unpack
@@ -352,6 +354,53 @@ class DocumentService(
         async with self.filter(**filters):
             async for item in self:
                 yield item
+
+    async def find_duplicate(
+        self,
+        content: bytes,
+        *,
+        filename: str | None = None,
+    ) -> Document | None:
+        """Return an existing document with matching MD5 checksum, or ``None``.
+
+        Paperless-ngx stores an MD5 hash of every uploaded file. This helper
+        computes the hash client-side and queries the API before you upload,
+        so you can skip the round-trip through the consume queue for known
+        duplicates. When ``filename`` is given, it is additionally matched
+        against ``original_filename`` (case-insensitive).
+
+        Args:
+            content:  Raw file bytes you intend to upload.
+            filename: Optional original filename to narrow the match further.
+
+        Example::
+
+            with open("invoice.pdf", "rb") as f:
+                content = f.read()
+
+            existing = await paperless.documents.find_duplicate(
+                content, filename="invoice.pdf"
+            )
+            if existing is not None:
+                print(f"Already uploaded as #{existing.id}: {existing.title}")
+            else:
+                draft = paperless.documents.create(
+                    document=content, filename="invoice.pdf"
+                )
+                await paperless.documents.save(draft)
+
+        """
+        checksum = await asyncio.to_thread(
+            lambda: hashlib.md5(content, usedforsecurity=False).hexdigest()
+        )
+        filters: DocumentFilters = {"checksum__iexact": checksum}
+        if filename is not None:
+            filters["original_filename__iexact"] = filename
+
+        async with self.filter(**filters):
+            async for doc in self:
+                return doc
+        return None
 
     async def email(
         self,

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -275,6 +275,42 @@ class TestDocuments:
             assert item.has_search_hit
             assert isinstance(item.search_hit, DocumentSearchHit)
 
+    async def test_find_duplicate(
+        self, httpx_mock: HTTPXMock, paperless: PaperlessClient
+    ) -> None:
+        """find_duplicate() hashes the bytes and returns the first match, or None."""
+        content = b"%PDF-fake-content"
+
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(
+                r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS}" + r"\?.*checksum.*$"
+            ),
+            status_code=200,
+            json=DATA_DOCUMENTS,
+        )
+        hit = await paperless.documents.find_duplicate(content, filename="invoice.pdf")
+        assert isinstance(hit, Document)
+        assert hit.id == DATA_DOCUMENTS["results"][0]["id"]
+
+        request = httpx_mock.get_requests()[-1]
+        assert "checksum__iexact=" in request.url.query.decode()
+        assert "original_filename__iexact=invoice.pdf" in request.url.query.decode()
+
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(
+                r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS}" + r"\?.*checksum.*$"
+            ),
+            status_code=200,
+            json={"count": 0, "next": None, "previous": "", "results": [], "all": []},
+        )
+        miss = await paperless.documents.find_duplicate(content)
+        assert miss is None
+
+        request = httpx_mock.get_requests()[-1]
+        assert "original_filename__iexact" not in request.url.query.decode()
+
     async def test_note_call(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
         """Notes list returns DocumentNote instances; missing pk raises PrimaryKeyRequiredError."""
         httpx_mock.add_response(

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -275,9 +275,7 @@ class TestDocuments:
             assert item.has_search_hit
             assert isinstance(item.search_hit, DocumentSearchHit)
 
-    async def test_find_duplicate(
-        self, httpx_mock: HTTPXMock, paperless: PaperlessClient
-    ) -> None:
+    async def test_find_duplicate(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
         """find_duplicate() hashes the bytes and returns the first match, or None."""
         content = b"%PDF-fake-content"
 


### PR DESCRIPTION
Computes the MD5 checksum of the given bytes client-side (in a worker
thread to keep the event loop responsive) and queries the documents
endpoint via checksum__iexact, optionally narrowed by
original_filename__iexact. Returns the first matching Document or None.

Closes #590.