### PR TITLE
Remove upper bound from requires-python constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
-requires-python = ">=3.12, <3.15"
+requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.13.2",
     "yarl>=1.22.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.12, <3.15"
+requires-python = ">=3.12"
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
## Summary

Relaxes the Python version constraint by removing the upper bound:

- `pyproject.toml`: `requires-python` changed from `">=3.12, <3.15"` to `">=3.12"`
- `uv.lock`: regenerated via `uv lock` to reflect the new constraint (no dependency changes)

This allows the package to be installed on Python 3.15 and future versions without requiring a new release just to lift the cap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxUcx5zvuB2mqpZfCf82b2)_