### PR TITLE
Review and improve tests

### DIFF
--- a/pypaperless/utils.py
+++ b/pypaperless/utils.py
@@ -52,6 +52,10 @@ class _FormDataBuilder:
                 self._add(name, item)
         elif isinstance(value, tuple | bytes):
             self._add_file(name, value)
+        elif hasattr(value, "read"):
+            # file-like objects go to httpx as-is; stringifying them would upload
+            # the object's repr instead of its content
+            self._files.append((name, value))
         else:
             self._add_scalar(name, value)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,12 @@ from pytest_httpx import HTTPXMock
 from pypaperless import PaperlessClient
 from pypaperless.const import EndpointPath
 
-from .const import PAPERLESS_TEST_TOKEN, PAPERLESS_TEST_URL
+from .const import (
+    PAPERLESS_TEST_API_VERSION,
+    PAPERLESS_TEST_TOKEN,
+    PAPERLESS_TEST_URL,
+    PAPERLESS_TEST_VERSION,
+)
 from .data import DATA_SCHEMA
 
 
@@ -33,6 +38,10 @@ async def paperless_fixture(
         method="GET",
         status_code=200,
         json=DATA_SCHEMA,
+        headers={
+            "x-api-version": str(PAPERLESS_TEST_API_VERSION),
+            "x-version": PAPERLESS_TEST_VERSION,
+        },
     )
     async with api:
         yield api

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,12 +19,16 @@ from .data import DATA_SCHEMA
 
 
 @pytest.fixture(name="api")
-def api_obj_fixture() -> PaperlessClient:
-    """Return PaperlessClient."""
-    return PaperlessClient(
+async def api_obj_fixture() -> AsyncGenerator[PaperlessClient, Any]:
+    """Return an uninitialized PaperlessClient and close its httpx client afterwards."""
+    api = PaperlessClient(
         PAPERLESS_TEST_URL,
         PAPERLESS_TEST_TOKEN,
     )
+    try:
+        yield api
+    finally:
+        await api.close()
 
 
 @pytest.fixture(name="paperless")

--- a/tests/const.py
+++ b/tests/const.py
@@ -4,3 +4,5 @@ PAPERLESS_TEST_URL = "https://paperless.not-existing.internal"
 PAPERLESS_TEST_TOKEN = "abcdef0123456789"
 PAPERLESS_TEST_USER = "test-user"
 PAPERLESS_TEST_PASSWORD = "not-so-secret-password"
+PAPERLESS_TEST_API_VERSION = 9
+PAPERLESS_TEST_VERSION = "2.18.4"

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -47,7 +47,7 @@ from .workflows import DATA_WORKFLOW_ACTIONS, DATA_WORKFLOW_TRIGGERS, DATA_WORKF
 
 
 def _read_schema() -> dict:
-    filepath = Path("tests/data/schema.json")
+    filepath = Path(__file__).parent / "schema.json"
     with Path.open(filepath, mode="r", encoding="utf-8") as file:
         return json.load(file)
 

--- a/tests/data/share_links.py
+++ b/tests/data/share_links.py
@@ -1,7 +1,7 @@
 """Share links snapshot."""
 
 DATA_SHARE_LINKS = {
-    "count": 5,
+    "count": 8,
     "next": None,
     "previous": None,
     "results": [

--- a/tests/data/storage_paths.py
+++ b/tests/data/storage_paths.py
@@ -1,7 +1,7 @@
 """Storage paths snapshot."""
 
 DATA_STORAGE_PATHS = {
-    "count": 3,
+    "count": 5,
     "next": None,
     "previous": None,
     "results": [

--- a/tests/data/tags.py
+++ b/tests/data/tags.py
@@ -1,7 +1,7 @@
 """Tags snapshot."""
 
 DATA_TAGS = {
-    "count": 2,
+    "count": 5,
     "next": None,
     "previous": None,
     "results": [

--- a/tests/data/workflows.py
+++ b/tests/data/workflows.py
@@ -125,24 +125,19 @@ DATA_WORKFLOWS = {
     ],
 }
 
+_ACTIONS = [action for wf in DATA_WORKFLOWS["results"] for action in wf["actions"]]
+_TRIGGERS = [trigger for wf in DATA_WORKFLOWS["results"] for trigger in wf["triggers"]]
+
 DATA_WORKFLOW_ACTIONS = {
-    "count": 0,
+    "count": len(_ACTIONS),
     "next": None,
     "previous": None,
-    "results": [],
+    "results": _ACTIONS,
 }
-for wf in DATA_WORKFLOWS["results"]:
-    DATA_WORKFLOW_ACTIONS["count"] += 1
-    for act in wf["actions"]:
-        DATA_WORKFLOW_ACTIONS["results"].append(act)
 
 DATA_WORKFLOW_TRIGGERS = {
-    "count": 0,
+    "count": len(_TRIGGERS),
     "next": None,
     "previous": None,
-    "results": [],
+    "results": _TRIGGERS,
 }
-for wf in DATA_WORKFLOWS["results"]:
-    DATA_WORKFLOW_TRIGGERS["count"] += 1
-    for act in wf["triggers"]:
-        DATA_WORKFLOW_TRIGGERS["results"].append(act)

--- a/tests/mappings.py
+++ b/tests/mappings.py
@@ -3,12 +3,11 @@
 from dataclasses import dataclass
 from typing import Any
 
-from pypaperless import models, services
+from pypaperless import models
 from pypaperless.const import PaperlessResource
 from pypaperless.models import types
 
 from .data import (
-    DATA_CONFIG,
     DATA_CORRESPONDENTS,
     DATA_CUSTOM_FIELDS,
     DATA_DOCUMENT_TYPES,
@@ -20,10 +19,8 @@ from .data import (
     DATA_SAVED_VIEWS,
     DATA_SHARE_LINK_BUNDLES,
     DATA_SHARE_LINKS,
-    DATA_STATUS,
     DATA_STORAGE_PATHS,
     DATA_TAGS,
-    DATA_TASKS,
     DATA_USERS,
     DATA_WORKFLOWS,
 )
@@ -35,7 +32,6 @@ class ResourceTestMapping:
 
     resource: str
     data: dict[str, Any] | list[dict[str, Any]]
-    service_cls: type
     model_cls: type
     draft_cls: type | None = None
     draft_defaults: dict[str, Any] | None = None
@@ -44,21 +40,11 @@ class ResourceTestMapping:
     # field and value used by test_update
     update_field: str = "name"
     update_value: Any = "Name Updated"
-    # explicit mock JSON for test_draft_save; None → {"id": N} default
-    draft_response_json: Any = None
 
-
-CONFIG_MAP = ResourceTestMapping(
-    PaperlessResource.CONFIG,
-    DATA_CONFIG,
-    services.ConfigService,
-    models.Config,
-)
 
 CORRESPONDENT_MAP = ResourceTestMapping(
     PaperlessResource.CORRESPONDENTS,
     DATA_CORRESPONDENTS,
-    services.CorrespondentService,
     models.Correspondent,
     models.CorrespondentDraft,
     {
@@ -72,7 +58,6 @@ CORRESPONDENT_MAP = ResourceTestMapping(
 CUSTOM_FIELD_MAP = ResourceTestMapping(
     PaperlessResource.CUSTOM_FIELDS,
     DATA_CUSTOM_FIELDS,
-    services.CustomFieldService,
     models.CustomField,
     models.CustomFieldDraft,
     {
@@ -85,7 +70,6 @@ CUSTOM_FIELD_MAP = ResourceTestMapping(
 DOCUMENT_MAP = ResourceTestMapping(
     PaperlessResource.DOCUMENTS,
     DATA_DOCUMENTS,
-    services.DocumentService,
     models.Document,
     models.DocumentDraft,
     {
@@ -100,13 +84,11 @@ DOCUMENT_MAP = ResourceTestMapping(
     },
     update_field="title",
     update_value="Updated Title",
-    draft_response_json="11112222-3333-4444-5555-666677778888",
 )
 
 DOCUMENT_TYPE_MAP = ResourceTestMapping(
     PaperlessResource.DOCUMENT_TYPES,
     DATA_DOCUMENT_TYPES,
-    services.DocumentTypeService,
     models.DocumentType,
     models.DocumentTypeDraft,
     {
@@ -120,42 +102,36 @@ DOCUMENT_TYPE_MAP = ResourceTestMapping(
 GROUP_MAP = ResourceTestMapping(
     PaperlessResource.GROUPS,
     DATA_GROUPS,
-    services.GroupService,
     models.Group,
 )
 
 MAIL_ACCOUNT_MAP = ResourceTestMapping(
     PaperlessResource.MAIL_ACCOUNTS,
     DATA_MAIL_ACCOUNTS,
-    services.MailAccountService,
     models.MailAccount,
 )
 
 MAIL_RULE_MAP = ResourceTestMapping(
     PaperlessResource.MAIL_RULES,
     DATA_MAIL_RULES,
-    services.MailRuleService,
     models.MailRule,
 )
 
 PROCESSED_MAIL_MAP = ResourceTestMapping(
     PaperlessResource.PROCESSED_MAIL,
     DATA_PROCESSED_MAIL,
-    services.ProcessedMailService,
     models.ProcessedMail,
 )
 
 SAVED_VIEW_MAP = ResourceTestMapping(
     PaperlessResource.SAVED_VIEWS,
     DATA_SAVED_VIEWS,
-    services.SavedViewService,
     models.SavedView,
 )
 
 SHARE_LINK_MAP = ResourceTestMapping(
     PaperlessResource.SHARE_LINKS,
     DATA_SHARE_LINKS,
-    services.ShareLinkService,
     models.ShareLink,
     models.ShareLinkDraft,
     {
@@ -171,7 +147,6 @@ SHARE_LINK_MAP = ResourceTestMapping(
 SHARE_LINK_BUNDLE_MAP = ResourceTestMapping(
     PaperlessResource.SHARE_LINK_BUNDLES,
     DATA_SHARE_LINK_BUNDLES,
-    services.ShareLinkBundleService,
     models.ShareLinkBundle,
     models.ShareLinkBundleDraft,
     {
@@ -183,17 +158,10 @@ SHARE_LINK_BUNDLE_MAP = ResourceTestMapping(
     update_value=5,
 )
 
-STATUS_MAP = ResourceTestMapping(
-    PaperlessResource.STATUS,
-    DATA_STATUS,
-    services.StatusService,
-    models.Status,
-)
 
 STORAGE_PATH_MAP = ResourceTestMapping(
     PaperlessResource.STORAGE_PATHS,
     DATA_STORAGE_PATHS,
-    services.StoragePathService,
     models.StoragePath,
     models.StoragePathDraft,
     {
@@ -208,7 +176,6 @@ STORAGE_PATH_MAP = ResourceTestMapping(
 TAG_MAP = ResourceTestMapping(
     PaperlessResource.TAGS,
     DATA_TAGS,
-    services.TagService,
     models.Tag,
     models.TagDraft,
     {
@@ -222,23 +189,15 @@ TAG_MAP = ResourceTestMapping(
     },
 )
 
-TASK_MAP = ResourceTestMapping(
-    PaperlessResource.TASKS,
-    DATA_TASKS,
-    services.TaskService,
-    models.Task,
-)
 
 USER_MAP = ResourceTestMapping(
     PaperlessResource.USERS,
     DATA_USERS,
-    services.UserService,
     models.User,
 )
 
 WORKFLOW_MAP = ResourceTestMapping(
     PaperlessResource.WORKFLOWS,
     DATA_WORKFLOWS,
-    services.WorkflowService,
     models.Workflow,
 )

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -8,6 +8,7 @@ lint.extend-select = [
 lint.extend-ignore = [
   "S101", # As these are tests, the usage of assert could be good practise, no?
   "S105", # Yes, we hardcoded passwords. It will be ok this time.
+  "S106", # Same for passwords passed as a keyword argument.
   "SLF001", # Tests will access private/protected members.
   "TC002", # pytest doesn't like this one.
 ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 """Tests for the PaperlessClient client: init, context, requests, URL, token, Page model."""
 
 import datetime
+import json
 import re
 from io import BytesIO
 from typing import Any
@@ -43,6 +44,10 @@ from tests.const import (
 )
 
 from .data import DATA_PATHS, DATA_TOKEN
+
+
+class _SentinelError(Exception):
+    """Exception type no library code catches, used to prove an error propagates unwrapped."""
 
 
 def _multipart_parts(body: str) -> dict[str, list[str]]:
@@ -111,61 +116,50 @@ async def test_context(httpx_mock: HTTPXMock, api: PaperlessClient) -> None:
         assert api.is_initialized
 
 
-async def test_init_error(httpx_mock: HTTPXMock, api: PaperlessClient) -> None:
-    """Test that initialization raises the correct errors for each failure mode."""
-    # connection error
-    httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
-    with pytest.raises(PaperlessConnectionError):
+@pytest.mark.parametrize(
+    ("transport_exc", "expected"),
+    [
+        (httpx.ConnectError("Connection refused"), PaperlessConnectionError),
+        (httpx.ReadTimeout("Read timed out"), PaperlessTimeoutError),
+        (httpx.RemoteProtocolError("Server disconnected"), PaperlessConnectionError),
+    ],
+    ids=["connect_error", "timeout", "other_transport_error"],
+)
+async def test_init_transport_error(
+    httpx_mock: HTTPXMock,
+    api: PaperlessClient,
+    transport_exc: Exception,
+    expected: type[Exception],
+) -> None:
+    """Transport-level failures during initialize() map onto typed pypaperless errors."""
+    httpx_mock.add_exception(transport_exc)
+    with pytest.raises(expected):
         await api.initialize()
 
-    # timeout
-    httpx_mock.add_exception(httpx.ReadTimeout("Read timed out"))
-    with pytest.raises(PaperlessTimeoutError):
-        await api.initialize()
 
-    # any other transport error
-    httpx_mock.add_exception(httpx.RemoteProtocolError("Server disconnected"))
-    with pytest.raises(PaperlessConnectionError):
-        await api.initialize()
-
-    # HTTP 401 - wrong token
+@pytest.mark.parametrize(
+    ("response_kwargs", "expected"),
+    [
+        ({"status_code": 401, "text": "any html"}, InvalidTokenError),
+        ({"status_code": 401, "json": {"detail": "User is inactive"}}, InactiveOrDeletedError),
+        ({"status_code": 403, "text": "any html"}, ForbiddenError),
+        ({"status_code": 200, "text": "any html"}, InitializationError),
+    ],
+    ids=["wrong_token", "inactive_user", "forbidden", "non_json_body"],
+)
+async def test_init_response_error(
+    httpx_mock: HTTPXMock,
+    api: PaperlessClient,
+    response_kwargs: dict[str, Any],
+    expected: type[Exception],
+) -> None:
+    """Unusable index responses during initialize() map onto typed pypaperless errors."""
     httpx_mock.add_response(
         url=f"{PAPERLESS_TEST_URL}{EndpointPath.INDEX}",
         method="GET",
-        status_code=401,
-        text="any html",
+        **response_kwargs,
     )
-    with pytest.raises(InvalidTokenError):
-        await api.initialize()
-
-    # HTTP 401 - inactive / deleted user
-    httpx_mock.add_response(
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.INDEX}",
-        method="GET",
-        status_code=401,
-        json={"detail": "User is inactive"},
-    )
-    with pytest.raises(InactiveOrDeletedError):
-        await api.initialize()
-
-    # HTTP 403 - forbidden
-    httpx_mock.add_response(
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.INDEX}",
-        method="GET",
-        status_code=403,
-        text="any html",
-    )
-    with pytest.raises(ForbiddenError):
-        await api.initialize()
-
-    # HTTP 200 with non-JSON body
-    httpx_mock.add_response(
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.INDEX}",
-        method="GET",
-        status_code=200,
-        text="any html",
-    )
-    with pytest.raises(InitializationError):
+    with pytest.raises(expected):
         await api.initialize()
 
 
@@ -257,10 +251,21 @@ async def test_request_json(httpx_mock: HTTPXMock, api: PaperlessClient) -> None
     [
         ("hostname", "https://hostname"),
         ("http://hostname", "http://hostname"),
+        # only http/https are recognised as schemes; anything else is treated as a
+        # hostname and gets the https:// prefix, producing a deliberately broken URL
+        # rather than silently talking to an unsupported scheme
         ("ftp://hostname", "https://ftp://hostname"),
         ("hostname:80", "https://hostname:80"),
         ("hostname/api/api/", "https://hostname/api/api"),
         ("hostname/api/endpoint///", "https://hostname/api/endpoint"),
+    ],
+    ids=[
+        "scheme_less",
+        "http_kept",
+        "unsupported_scheme",
+        "explicit_port",
+        "trailing_slash",
+        "repeated_trailing_slashes",
     ],
 )
 def test_create_url(input_url: str, expected: str) -> None:
@@ -268,142 +273,129 @@ def test_create_url(input_url: str, expected: str) -> None:
     assert normalize_base_url(input_url) == expected
 
 
-async def test_generate_api_token(httpx_mock: HTTPXMock) -> None:
-    """Test token generation success and failure modes."""
+@pytest.mark.parametrize(
+    "url",
+    [PAPERLESS_TEST_URL, PAPERLESS_TEST_URL.removeprefix("https://")],
+    ids=["absolute_url", "scheme_less_url"],
+)
+async def test_generate_api_token(httpx_mock: HTTPXMock, url: str) -> None:
+    """generate_api_token() returns the token and normalizes scheme-less URLs."""
     httpx_mock.add_response(
         url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
         method="POST",
         status_code=200,
         json=DATA_TOKEN,
     )
+    token = await generate_api_token(url, PAPERLESS_TEST_USER, PAPERLESS_TEST_PASSWORD)
+    assert token == PAPERLESS_TEST_TOKEN
+
+    body = json.loads(httpx_mock.get_requests()[-1].content)
+    assert body == {"username": PAPERLESS_TEST_USER, "password": PAPERLESS_TEST_PASSWORD}
+
+
+@pytest.mark.parametrize(
+    ("response_kwargs", "expected"),
+    [
+        ({"status_code": 200, "json": {"blah": "any string"}}, BadJsonResponseError),
+        (
+            {"status_code": 400, "json": {"non_field_errors": ["Unable to log in."]}},
+            JsonResponseWithError,
+        ),
+    ],
+    ids=["token_key_missing", "login_rejected"],
+)
+async def test_generate_api_token_response_error(
+    httpx_mock: HTTPXMock, response_kwargs: dict[str, Any], expected: type[Exception]
+) -> None:
+    """An unusable token response raises the matching typed error."""
+    httpx_mock.add_response(
+        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
+        method="POST",
+        **response_kwargs,
+    )
+    with pytest.raises(expected):
+        await generate_api_token(PAPERLESS_TEST_URL, PAPERLESS_TEST_USER, PAPERLESS_TEST_PASSWORD)
+
+
+@pytest.mark.parametrize(
+    ("transport_exc", "expected"),
+    [
+        (httpx.ConnectTimeout("Connect timed out"), PaperlessTimeoutError),
+        (httpx.ConnectError("Connection refused"), PaperlessConnectionError),
+        # a genuinely unexpected error must surface unwrapped; a bare ValueError would
+        # also match JSONDecodeError, which the function maps onto BadJsonResponseError
+        (_SentinelError(), _SentinelError),
+    ],
+    ids=["timeout", "connect_error", "unexpected_error_propagates"],
+)
+async def test_generate_api_token_transport_error(
+    httpx_mock: HTTPXMock, transport_exc: Exception, expected: type[Exception]
+) -> None:
+    """Transport errors are wrapped like in PaperlessTransport; others propagate as-is."""
+    httpx_mock.add_exception(
+        transport_exc,
+        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
+        method="POST",
+    )
+    with pytest.raises(expected):
+        await generate_api_token(PAPERLESS_TEST_URL, PAPERLESS_TEST_USER, PAPERLESS_TEST_PASSWORD)
+
+
+async def test_generate_api_token_leaves_external_client_open(httpx_mock: HTTPXMock) -> None:
+    """A caller-supplied client is used for the request but never closed."""
+    httpx_mock.add_response(
+        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
+        method="POST",
+        status_code=200,
+        json=DATA_TOKEN,
+    )
+    external = httpx.AsyncClient()
     token = await generate_api_token(
         PAPERLESS_TEST_URL,
         PAPERLESS_TEST_USER,
         PAPERLESS_TEST_PASSWORD,
+        client=external,
     )
     assert token == PAPERLESS_TEST_TOKEN
-
-    # scheme-less URLs are normalized like in PaperlessClient
-    httpx_mock.add_response(
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
-        method="POST",
-        status_code=200,
-        json=DATA_TOKEN,
-    )
-    token = await generate_api_token(
-        PAPERLESS_TEST_URL.removeprefix("https://"),
-        PAPERLESS_TEST_USER,
-        PAPERLESS_TEST_PASSWORD,
-    )
-    assert token == PAPERLESS_TEST_TOKEN
-
-    httpx_mock.add_response(
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
-        method="POST",
-        status_code=200,
-        json={"blah": "any string"},
-    )
-    with pytest.raises(BadJsonResponseError):
-        await generate_api_token(
-            PAPERLESS_TEST_URL,
-            PAPERLESS_TEST_USER,
-            PAPERLESS_TEST_PASSWORD,
-        )
-
-    httpx_mock.add_response(
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
-        method="POST",
-        status_code=400,
-        json={"non_field_errors": ["Unable to log in."]},
-    )
-    with pytest.raises(JsonResponseWithError):
-        await generate_api_token(
-            PAPERLESS_TEST_URL,
-            PAPERLESS_TEST_USER,
-            PAPERLESS_TEST_PASSWORD,
-        )
-
-    httpx_mock.add_exception(
-        ValueError(),
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
-        method="POST",
-    )
-    with pytest.raises(ValueError):  # noqa: PT011
-        await generate_api_token(
-            PAPERLESS_TEST_URL,
-            PAPERLESS_TEST_USER,
-            PAPERLESS_TEST_PASSWORD,
-        )
-
-    # transport errors are wrapped like in PaperlessTransport
-    httpx_mock.add_exception(
-        httpx.ConnectTimeout("Connect timed out"),
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
-        method="POST",
-    )
-    with pytest.raises(PaperlessTimeoutError):
-        await generate_api_token(
-            PAPERLESS_TEST_URL,
-            PAPERLESS_TEST_USER,
-            PAPERLESS_TEST_PASSWORD,
-        )
-
-    httpx_mock.add_exception(
-        httpx.ConnectError("Connection refused"),
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
-        method="POST",
-    )
-    with pytest.raises(PaperlessConnectionError):
-        await generate_api_token(
-            PAPERLESS_TEST_URL,
-            PAPERLESS_TEST_USER,
-            PAPERLESS_TEST_PASSWORD,
-        )
-
-    # passing an explicit httpx client still returns the correct token
-    httpx_mock.add_response(
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.TOKEN}",
-        method="POST",
-        status_code=200,
-        json=DATA_TOKEN,
-    )
-    token = await generate_api_token(
-        PAPERLESS_TEST_URL,
-        PAPERLESS_TEST_USER,
-        PAPERLESS_TEST_PASSWORD,
-        client=httpx.AsyncClient(),
-    )
-    assert token == PAPERLESS_TEST_TOKEN
+    assert not external.is_closed
+    await external.aclose()
 
 
-async def test_pages_object(api: PaperlessClient) -> None:
-    """Test Page model construction, iteration, and navigation helpers."""
+class _PagedTestResource(PaperlessModel):
+    """Minimal model used to deserialize Page.results in the Page unit tests."""
 
-    class TestResource(PaperlessModel):
-        id: int | None = None
+    id: int | None = None
 
-    data: dict = {
-        "count": 0,
-        "next": "any.url",
-        "previous": None,
-        "all": [],
-        "results": [],
-    }
-    for i in range(1, 101):
-        data["count"] += 1
-        data["all"].append(i)
-        data["results"].append({"id": i})
 
-    page = Page.from_data(
-        api._runtime, data, resource_cls=TestResource, current_page=1, page_size=25
+def _page_of(
+    api: PaperlessClient, *, current_page: int, next_url: str | None, previous_url: str | None
+) -> Page[_PagedTestResource]:
+    """Build one page of a 100-item, 25-per-page result set."""
+    start = (current_page - 1) * 25 + 1
+    return Page.from_data(
+        api._runtime,
+        {
+            "count": 100,
+            "next": next_url,
+            "previous": previous_url,
+            "results": [{"id": i} for i in range(start, start + 25)],
+        },
+        resource_cls=_PagedTestResource,
+        current_page=current_page,
+        page_size=25,
     )
 
-    assert isinstance(page, Page)
-    assert page.current_count == 100
+
+def test_pages_object_first_page(api: PaperlessClient) -> None:
+    """The first page reports no previous page and points at page 2."""
+    page = _page_of(api, current_page=1, next_url="any.url", previous_url=None)
+
+    assert page.current_count == 25
+    assert len(page.items) == 25
+    assert [item.id for item in page][:3] == [1, 2, 3]
     for item in page:
-        assert isinstance(item, TestResource)
+        assert isinstance(item, _PagedTestResource)
 
-    # first page
     assert not page.has_previous_page
     assert page.has_next_page
     assert not page.is_last_page
@@ -411,21 +403,29 @@ async def test_pages_object(api: PaperlessClient) -> None:
     assert page.next_page == 2
     assert page.previous_page is None
 
-    # inner page
-    page.previous = "any.url"
-    page._current_page = 3
-    assert page.previous_page is not None
-    assert page.next_page is not None
+
+def test_pages_object_inner_page(api: PaperlessClient) -> None:
+    """An inner page reports both neighbours with the correct page numbers."""
+    page = _page_of(api, current_page=3, next_url="any.url", previous_url="any.url")
+
+    assert page.previous_page == 2
+    assert page.next_page == 4
+    assert page.has_previous_page
+    assert page.has_next_page
     assert not page.is_last_page
 
-    # last page
-    page.next = None
-    page._current_page = 4
+
+def test_pages_object_last_page(api: PaperlessClient) -> None:
+    """The last page has no next page and identifies itself as last."""
+    page = _page_of(api, current_page=4, next_url=None, previous_url="any.url")
+
+    assert page.previous_page == 3
     assert page.next_page is None
     assert page.is_last_page
+    assert page.last_page == 4
 
 
-async def test_draft_not_supported(api: PaperlessClient) -> None:
+def test_draft_not_supported(api: PaperlessClient) -> None:
     """Test that CreatableService.create() raises when no draft_cls is configured."""
 
     class TestResource(PaperlessModel):
@@ -441,7 +441,7 @@ async def test_draft_not_supported(api: PaperlessClient) -> None:
         service.create()
 
 
-async def test_draft_rejects_unknown_fields(api: PaperlessClient) -> None:
+def test_draft_rejects_unknown_fields(api: PaperlessClient) -> None:
     """Draft models forbid unknown kwargs, so typos fail at create() time."""
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         api.tags.create(tag_name="typo")  # wrong keyword for 'name'
@@ -451,7 +451,7 @@ async def test_draft_rejects_unknown_fields(api: PaperlessClient) -> None:
     assert draft.name == "valid"
 
 
-async def test_validate_assignment(api: PaperlessClient) -> None:
+def test_validate_assignment(api: PaperlessClient) -> None:
     """Field assignments are validated and coerced in place."""
 
     class AssignModel(PaperlessModel):
@@ -474,7 +474,7 @@ async def test_validate_assignment(api: PaperlessClient) -> None:
         model.tags = bad_tags
 
 
-async def test_snapshot_lazy(api: PaperlessClient) -> None:
+def test_snapshot_lazy(api: PaperlessClient) -> None:
     """Snapshot derives from the raw API payload even when first read after a mutation."""
 
     class LazyModel(PaperlessModel):
@@ -493,7 +493,7 @@ async def test_snapshot_lazy(api: PaperlessClient) -> None:
     assert direct.snapshot["title"] == "x"
 
 
-async def test_api_dump(api: PaperlessClient) -> None:
+def test_api_dump(api: PaperlessClient) -> None:
     """api_dump() serializes by alias, honors exclude markers and JSON-mode conversion."""
 
     class SubModel(BaseModel):
@@ -616,7 +616,7 @@ async def test_owned_client_closed_on_close(httpx_mock: HTTPXMock) -> None:
     assert transport._httpx_client.is_closed
 
 
-async def test_service_base_api_path(api: PaperlessClient) -> None:
+def test_service_base_api_path(api: PaperlessClient) -> None:
     """ResourceService.api_path property returns the configured _api_path."""
 
     class _TestService(ResourceService):
@@ -634,11 +634,6 @@ def test_process_form_data_tuple_len1() -> None:
     assert name == "doc"
     assert isinstance(fobj, BytesIO)
     assert fobj.read() == b"raw bytes"
-
-
-# ---------------------------------------------------------------------------
-# PaperlessSettings / multi-mode init tests
-# ---------------------------------------------------------------------------
 
 
 def test_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -680,14 +675,14 @@ def test_settings_token_is_secret(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 async def test_transport_close_without_prior_request() -> None:
-    """transport.close() must be a no-op when no httpx client was ever created (L65->exit)."""
+    """transport.close() must be a no-op when no httpx client was ever created."""
     transport = PaperlessTransport(PAPERLESS_TEST_URL, PAPERLESS_TEST_TOKEN)
     assert transport._httpx_client is None
     await transport.close()  # must not raise
 
 
 async def test_request_without_token(httpx_mock: HTTPXMock) -> None:
-    """_send must omit the Authorization header when token is None (L106->109)."""
+    """_send must omit the Authorization header when the token is None."""
     transport = PaperlessTransport(PAPERLESS_TEST_URL, token=None)
     httpx_mock.add_response(
         url=f"{PAPERLESS_TEST_URL}/api/",
@@ -704,12 +699,12 @@ async def test_request_without_token(httpx_mock: HTTPXMock) -> None:
 
 def test_page_items_raises_without_resource_cls(api: PaperlessClient) -> None:
     """Page.items raises RuntimeError when no resource_cls was supplied at construction."""
-    # from_data without resource_cls= → model_post_init skips L36 True-branch (L36->exit).
+    # from_data without resource_cls= leaves _resource_cls unset
     page = Page.from_data(
         api._runtime,
         {"count": 1, "next": None, "previous": None, "all": [1], "results": [{"id": 1}]},
     )
-    # Accessing .items triggers mapper; _resource_cls is None → L71-72.
+    # accessing .items runs the mapper, which raises without a resource class
     with pytest.raises(RuntimeError, match="resource_cls"):
         _ = page.items
 
@@ -717,11 +712,7 @@ def test_page_items_raises_without_resource_cls(api: PaperlessClient) -> None:
 async def test_page_generator_follows_next_and_prefetches(
     httpx_mock: HTTPXMock, api: PaperlessClient
 ) -> None:
-    """PageGenerator follows the server-provided next URL across pages."""
-
-    class PagedResource(PaperlessModel):
-        id: int | None = None
-
+    """PageGenerator follows the next URL and fetches page 2 before it is asked for."""
     page1 = {
         "count": 3,
         "next": f"{PAPERLESS_TEST_URL}/api/things/?page=2",
@@ -734,8 +725,15 @@ async def test_page_generator_follows_next_and_prefetches(
     )
     httpx_mock.add_response(url=f"{PAPERLESS_TEST_URL}/api/things/?page=2", json=page2)
 
-    gen = PageGenerator(api.runtime, "/api/things/", PagedResource)
-    pages = [page async for page in gen]
+    gen = PageGenerator(api.runtime, "/api/things/", _PagedTestResource)
+    first = await anext(gen)
+    assert first.current_page == 1
+    # the prefetch for page 2 is in flight before the consumer asks for it
+    assert gen._prefetch is not None
+    await gen._prefetch
+    assert len(httpx_mock.get_requests()) == 2
+
+    pages = [first, *[page async for page in gen]]
     assert [page.current_page for page in pages] == [1, 2]
     assert pages[0].has_next_page
     assert pages[1].is_last_page
@@ -746,10 +744,6 @@ async def test_page_generator_aclose_cancels_prefetch(
     httpx_mock: HTTPXMock, api: PaperlessClient
 ) -> None:
     """Abandoning iteration early cancels the pending prefetch via aclose()."""
-
-    class PagedResource(PaperlessModel):
-        id: int | None = None
-
     page1 = {
         "count": 2,
         "next": f"{PAPERLESS_TEST_URL}/api/things/?page=2",
@@ -766,7 +760,7 @@ async def test_page_generator_aclose_cancels_prefetch(
         is_optional=True,
     )
 
-    gen = PageGenerator(api.runtime, "/api/things/", PagedResource)
+    gen = PageGenerator(api.runtime, "/api/things/", _PagedTestResource)
     first = await anext(gen)
     assert first.current_page == 1
     await gen.aclose()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 """Tests for the PaperlessClient client: init, context, requests, URL, token, Page model."""
 
 import datetime
+import re
 from io import BytesIO
 from typing import Any
 
@@ -10,7 +11,7 @@ from pydantic import BaseModel, Field, ValidationError
 from pytest_httpx import HTTPXMock
 
 from pypaperless import PaperlessClient, PaperlessSettings, generate_api_token
-from pypaperless.const import EndpointPath
+from pypaperless.const import API_VERSION, EndpointPath
 from pypaperless.exceptions import (
     BadJsonResponseError,
     DeletionError,
@@ -33,13 +34,23 @@ from pypaperless.services.base import ResourceService
 from pypaperless.transport import PaperlessTransport
 from pypaperless.utils import normalize_base_url, process_form_data
 from tests.const import (
+    PAPERLESS_TEST_API_VERSION,
     PAPERLESS_TEST_PASSWORD,
     PAPERLESS_TEST_TOKEN,
     PAPERLESS_TEST_URL,
     PAPERLESS_TEST_USER,
+    PAPERLESS_TEST_VERSION,
 )
 
 from .data import DATA_PATHS, DATA_TOKEN
+
+
+def _multipart_parts(body: str) -> dict[str, list[str]]:
+    """Return ``{field name: [value, ...]}`` for a multipart/form-data body."""
+    parts: dict[str, list[str]] = {}
+    for match in re.finditer(r'name="([^"]+)"[^\r\n]*\r\n(?:[^\r\n]+\r\n)*\r\n(.*?)\r\n--', body):
+        parts.setdefault(match.group(1), []).append(match.group(2))
+    return parts
 
 
 async def test_init(httpx_mock: HTTPXMock, api: PaperlessClient) -> None:
@@ -52,6 +63,39 @@ async def test_init(httpx_mock: HTTPXMock, api: PaperlessClient) -> None:
     )
     await api.initialize()
     assert api.is_initialized
+    await api.close()
+
+
+async def test_init_reads_version_headers(httpx_mock: HTTPXMock, api: PaperlessClient) -> None:
+    """initialize() picks host_api_version / host_version up from the response headers."""
+    httpx_mock.add_response(
+        url=f"{PAPERLESS_TEST_URL}{EndpointPath.INDEX}",
+        method="GET",
+        status_code=200,
+        json=DATA_PATHS,
+        headers={
+            "x-api-version": str(PAPERLESS_TEST_API_VERSION),
+            "x-version": PAPERLESS_TEST_VERSION,
+        },
+    )
+    await api.initialize()
+    assert api.host_api_version == PAPERLESS_TEST_API_VERSION
+    assert api.host_version == PAPERLESS_TEST_VERSION
+    assert api.runtime.api_version == PAPERLESS_TEST_API_VERSION
+    await api.close()
+
+
+async def test_init_without_version_headers(httpx_mock: HTTPXMock, api: PaperlessClient) -> None:
+    """A host that sends no version headers falls back to the compiled-in API version."""
+    httpx_mock.add_response(
+        url=f"{PAPERLESS_TEST_URL}{EndpointPath.INDEX}",
+        method="GET",
+        status_code=200,
+        json=DATA_PATHS,
+    )
+    await api.initialize()
+    assert api.host_api_version == API_VERSION
+    assert api.host_version is None
     await api.close()
 
 
@@ -132,7 +176,7 @@ async def test_request(httpx_mock: HTTPXMock) -> None:
 
     httpx_mock.add_response(url=PAPERLESS_TEST_URL, method="GET", status_code=200)
     res = await api._runtime.transport.request_raw("get", PAPERLESS_TEST_URL)
-    assert res.status_code
+    assert res.status_code == 200
 
     form_data = {
         "none_field": None,
@@ -146,7 +190,28 @@ async def test_request(httpx_mock: HTTPXMock) -> None:
     }
     httpx_mock.add_response(url=PAPERLESS_TEST_URL, method="POST", status_code=200)
     res = await api._runtime.transport.request_raw("post", PAPERLESS_TEST_URL, form=form_data)
-    assert res.status_code
+    assert res.status_code == 200
+
+    body = httpx_mock.get_requests()[-1].content.decode()
+    parts = _multipart_parts(body)
+
+    # None is dropped entirely
+    assert "none_field" not in parts
+    # scalars are stringified
+    assert parts["str_field"] == ["Hello Bytes!"]
+    assert parts["int_field"] == ["23"]
+    assert parts["float_field"] == ["13.37"]
+    # lists become repeated values under the same name
+    assert parts["int_list"] == ["1", "1", "2", "3", "5", "8", "13"]
+    # dicts are flattened, the outer key disappears
+    assert "dict_field" not in parts
+    assert parts["dict_str_field"] == ["str"]
+    assert parts["dict_int_field"] == ["2"]
+    # bytes become an unnamed file, 2-tuples carry the filename
+    assert 'name="bytes_field"; filename=' in body
+    assert parts["bytes_field"] == ["Hello String!"]
+    assert 'name="tuple_field"; filename="filename.pdf"' in body
+    assert parts["tuple_field"] == ["Document Content"]
 
     await api.close()
 
@@ -593,8 +658,12 @@ def test_config_from_env_missing_url(monkeypatch: pytest.MonkeyPatch) -> None:
         PaperlessClient.from_env()
 
 
-def test_settings_token_is_secret() -> None:
+def test_settings_token_is_secret(monkeypatch: pytest.MonkeyPatch) -> None:
     """The token never leaks through repr/str; from_config unwraps it for the transport."""
+    # PaperlessSettings is a BaseSettings — a PYPAPERLESS_TOKEN in the developer's
+    # environment would otherwise populate the deliberately anonymous config below
+    monkeypatch.delenv("PYPAPERLESS_TOKEN", raising=False)
+
     cfg = PaperlessSettings(url=PAPERLESS_TEST_URL, token=PAPERLESS_TEST_TOKEN)
     assert PAPERLESS_TEST_TOKEN not in repr(cfg)
     assert PAPERLESS_TEST_TOKEN not in str(cfg)

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -17,8 +17,7 @@ from pypaperless.builders.custom_fields import (
     _CustomFieldQueryOr,
 )
 from pypaperless.const import EndpointPath
-from pypaperless.models import CustomField, Tag
-from pypaperless.models.mixins.data_fields import MatchingAlgorithm
+from pypaperless.models import CustomField
 from pypaperless.models.types import (
     CustomFieldBooleanValue,
     CustomFieldDateValue,
@@ -33,10 +32,6 @@ from pypaperless.models.types import (
 from .const import PAPERLESS_TEST_URL
 from .data import DATA_CUSTOM_FIELDS
 
-# ---------------------------------------------------------------------------
-# CustomField value types
-# ---------------------------------------------------------------------------
-
 
 async def test_draft_value_without_cache(paperless: PaperlessClient) -> None:
     """draft_value() returns a plain object when the custom field cache is empty."""
@@ -46,6 +41,8 @@ async def test_draft_value_without_cache(paperless: PaperlessClient) -> None:
     )
     field_value = custom_field.draft_value(1337)
     assert type(field_value) is CustomFieldValue
+    assert field_value.field == custom_field.id
+    assert field_value.value == 1337
 
 
 async def test_draft_value_with_cache(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
@@ -65,7 +62,8 @@ async def test_draft_value_with_cache(httpx_mock: HTTPXMock, paperless: Paperles
         data=DATA_CUSTOM_FIELDS["results"][5],
     )
     field_value = custom_field.draft_value(1337, expected_type=CustomFieldIntegerValue)
-    assert isinstance(field_value, CustomFieldIntegerValue)
+    assert field_value.field == custom_field.id
+    assert field_value.value == 1337
 
 
 @pytest.mark.parametrize(
@@ -75,7 +73,7 @@ async def test_draft_value_with_cache(httpx_mock: HTTPXMock, paperless: Paperles
 )
 def test_date_value_parses_to_date(value_str: str) -> None:
     """CustomFieldDateValue accepts both ISO date strings and datetime strings, returning a date."""
-    assert isinstance(CustomFieldDateValue(value=value_str).value, date)
+    assert CustomFieldDateValue(value=value_str).value == date(1900, 1, 2)
 
 
 def test_monetary_value_parsing() -> None:
@@ -120,15 +118,10 @@ def test_select_value_labels() -> None:
             ]
         },
     )
-    assert isinstance(test.labels, list)
+    assert [option.label for option in test.labels] == ["label1", "label2"]
     assert test.label == "label2"
     test.extra_data = None
     assert test.label is None
-
-
-# ---------------------------------------------------------------------------
-# CustomFieldQuery DSL
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -226,51 +219,8 @@ def test_date_value_accepts_date_object() -> None:
     assert field.value == d
 
 
-def test_tag_with_nested_children(api: PaperlessClient) -> None:
-    """Tag._validate_children builds nested Tag instances from raw dict children."""
-    tag_data = {
-        "id": 1,
-        "slug": "parent",
-        "name": "Parent Tag",
-        "color": "#000000",
-        "text_color": "#ffffff",
-        "matching_algorithm": 2,
-        "children": [
-            {
-                "id": 2,
-                "slug": "child",
-                "name": "Child Tag",
-                "color": "#000000",
-                "text_color": "#ffffff",
-                "matching_algorithm": 1,
-                "children": [
-                    {
-                        "id": 3,
-                        "slug": "grandchild",
-                        "name": "Grandchild Tag",
-                        "color": "#000000",
-                        "text_color": "#ffffff",
-                        "matching_algorithm": 6,
-                    }
-                ],
-            }
-        ],
-    }
-    tag = Tag.from_data(api._runtime, data=tag_data)
-    assert tag.name == "Parent Tag"
-    assert isinstance(tag.children, list)
-    child = tag.children[0]
-    assert isinstance(child, Tag)
-    assert child.name == "Child Tag"
-    assert child.matching_algorithm == MatchingAlgorithm.ANY
-    assert isinstance(child.children, list)
-    assert isinstance(child.children[0], Tag)
-    assert child.children[0].name == "Grandchild Tag"
-    assert child.children[0].matching_algorithm == MatchingAlgorithm.AUTO
-
-
 def test_draft_value_raises_for_wrong_expected_type(api: PaperlessClient) -> None:
-    """draft_value() must raise TypeError when result type mismatches expected_type (L245-246)."""
+    """draft_value() must raise TypeError when the result type mismatches expected_type."""
     # Build a CustomField with no cache so draft_value returns a plain CustomFieldValue.
     cf = CustomField.from_data(api._runtime, {"id": 99, "name": "test", "data_type": "integer"})
     # Without cache the result is CustomFieldValue, not CustomFieldBooleanValue.
@@ -279,4 +229,6 @@ def test_draft_value_raises_for_wrong_expected_type(api: PaperlessClient) -> Non
 
     # Passing expected_type=None must not raise (the guard is skipped).
     result = cf.draft_value(42)
-    assert result is not None
+    assert type(result) is CustomFieldValue
+    assert result.field == 99
+    assert result.value == 42

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,5 +1,6 @@
 """Tests for the model operation dispatcher."""
 
+from collections.abc import Generator
 from typing import ClassVar
 
 import pytest
@@ -22,19 +23,14 @@ from pypaperless.services.mixins import DeletableService
 from .const import PAPERLESS_TEST_URL
 from .data import DATA_CORRESPONDENTS
 
-# ---------------------------------------------------------------------------
-# Module-level helpers for DispatchableCachedProperty.__set_name__ edge cases
-#
-# Annotation mutation trick: define a function with a valid annotation that
-# mypy can check, then replace __annotations__["return"] at module level with
-# an unresolvable string so get_type_hints() raises NameError at runtime.
-# This lets us cover defensive exception-handling branches without using any
-# suppression comment.
-# ---------------------------------------------------------------------------
+# The helpers below cover DispatchableCachedProperty.__set_name__ edge cases via an
+# annotation mutation trick: declare a return annotation mypy can check, then replace
+# __annotations__["return"] with an unresolvable string so get_type_hints() raises at
+# runtime. That reaches the defensive branches without any suppression comment.
 
 
 def _factory_bad_type_hint(self: object) -> PaperlessService:
-    """Provide a runtime-unresolvable return annotation (exercises L62-63)."""
+    """Provide a runtime-unresolvable return annotation."""
     raise NotImplementedError
 
 
@@ -43,7 +39,7 @@ _factory_bad_type_hint.__annotations__["return"] = "_UndefinedTypeAtRuntime_XYZA
 
 
 def _factory_no_return_annotation(self: object) -> PaperlessService:
-    """Remove return annotation so hints.get('return') is None (exercises L66)."""
+    """Remove return annotation so hints.get('return') is None."""
     raise NotImplementedError
 
 
@@ -52,7 +48,7 @@ del _factory_no_return_annotation.__annotations__["return"]
 
 
 def _factory_base_service_return(self: object) -> PaperlessService:
-    """Return PaperlessService base (no _resource_cls/_draft_cls, exercises L69->67)."""
+    """Return the PaperlessService base, which has neither _resource_cls nor _draft_cls."""
     raise NotImplementedError
 
 
@@ -66,17 +62,17 @@ class _FakeWritableSubSvc(
     ResourceService,
     DeletableService[_FakeDispatchTestModel],
 ):
-    """Writable sub-service with _resource_cls but no _draft_cls (exercises L85->83)."""
+    """Writable sub-service with _resource_cls but no _draft_cls."""
 
     _api_path = "/api/dispatch-fake/"
     _resource = PaperlessResource.DOCUMENTS
 
     _resource_cls = _FakeDispatchTestModel
-    # Deliberately omit _draft_cls so the loop's False branch (L85->83) is taken.
+    # _draft_cls is deliberately omitted so the registration loop skips the draft branch.
 
 
 def _bad_sub_fget(self: object) -> PaperlessService:
-    """Property getter for bad_sub; annotation replaced below (L76-77 coverage)."""
+    """Property getter for bad_sub; its annotation is made unresolvable below."""
     raise NotImplementedError
 
 
@@ -87,23 +83,34 @@ _bad_sub_fget.__annotations__["return"] = "_UndefinedSubTypeAtRuntime_XYZABC"
 class _FakeSvcWithSubProps(PaperlessService):
     """Service with sub-properties exercising __set_name__ sub-discovery edge cases."""
 
-    # bad_sub: annotation is an unresolvable string → get_type_hints raises (L76-77).
+    # bad_sub: annotation is an unresolvable string → get_type_hints raises.
     bad_sub: property = property(_bad_sub_fget)
 
     @property
     def str_sub(self) -> str:
-        """Sub-property returning str — not a PaperlessService subclass (L80)."""
+        """Sub-property returning str — not a PaperlessService subclass."""
         return ""
 
     @property
     def writable_sub(self) -> _FakeWritableSubSvc:
-        """Writable sub-service without _draft_cls — exercises L85->83 branch."""
+        """Writable sub-service without _draft_cls."""
         raise NotImplementedError
 
 
 def _factory_fake_with_sub_props(self: object) -> _FakeSvcWithSubProps:
-    """Return _FakeSvcWithSubProps for __set_name__ sub-discovery edge-case coverage."""
+    """Return _FakeSvcWithSubProps for __set_name__ sub-discovery edge cases."""
     raise NotImplementedError
+
+
+@pytest.fixture(name="restore_registry")
+def restore_registry_fixture() -> Generator[None]:
+    """Undo registry writes made by __set_name__ so later tests see a clean registry."""
+    before = dict(_MODEL_TO_PROP_NAME)
+    try:
+        yield
+    finally:
+        _MODEL_TO_PROP_NAME.clear()
+        _MODEL_TO_PROP_NAME.update(before)
 
 
 class TestDispatcherInit:
@@ -215,55 +222,45 @@ class TestDispatchableCachedPropertyBehavior:
         assert isinstance(result, dispatchable_cached_property)
 
     def test_set_name_silences_type_hints_error(self) -> None:
-        """__set_name__ must return silently when get_type_hints raises (L62-63)."""
+        """__set_name__ must return silently when get_type_hints raises."""
         prop = DispatchableCachedProperty(_factory_bad_type_hint)
         prop.__set_name__(object, "bad_hint_prop")
         assert prop._attr_name == "bad_hint_prop"
 
+    @pytest.mark.usefixtures("restore_registry")
     def test_set_name_skips_non_service_return(self) -> None:
-        """__set_name__ must not touch the registry when return is not a service (L66)."""
+        """__set_name__ must not touch the registry when the return type is not a service."""
         prop = DispatchableCachedProperty(_factory_no_return_annotation)
         before = dict(_MODEL_TO_PROP_NAME)
         prop.__set_name__(object, "no_return_prop")
         assert before == _MODEL_TO_PROP_NAME
 
+    @pytest.mark.usefixtures("restore_registry")
     def test_set_name_handles_service_without_model_cls(self) -> None:
-        """__set_name__ must not crash when _resource_cls/_draft_cls are absent (L69->67).
-
-        PaperlessService base has neither attribute, so both loop iterations take the False branch.
-        """
+        """__set_name__ must not crash when _resource_cls/_draft_cls are absent."""
         prop = DispatchableCachedProperty(_factory_base_service_return)
         before = dict(_MODEL_TO_PROP_NAME)
         prop.__set_name__(object, "base_svc_prop")
         assert before == _MODEL_TO_PROP_NAME
 
-    def test_set_name_sub_prop_silences_type_hints_error(self) -> None:
-        """__set_name__ must silently skip sub-properties with unresolvable annotations (L76-77)."""
-        prop = DispatchableCachedProperty(_factory_fake_with_sub_props)
-        prop.__set_name__(object, "fake_sub_prop_a")
-        assert prop._attr_name == "fake_sub_prop_a"
-        _MODEL_TO_PROP_NAME.pop(_FakeDispatchTestModel, None)
+    @pytest.mark.usefixtures("restore_registry")
+    def test_set_name_sub_prop_discovery(self) -> None:
+        """Sub-property discovery registers only the writable sub-service.
 
-    def test_set_name_sub_prop_skips_non_service(self) -> None:
-        """__set_name__ must skip sub-properties that return a non-PaperlessService type (L80)."""
-        prop = DispatchableCachedProperty(_factory_fake_with_sub_props)
-        prop.__set_name__(object, "fake_sub_prop_b")
-        assert str not in _MODEL_TO_PROP_NAME
-        _MODEL_TO_PROP_NAME.pop(_FakeDispatchTestModel, None)
-
-    def test_set_name_sub_prop_handles_missing_draft_cls(self) -> None:
-        """__set_name__ must handle a writable sub-service with only _resource_cls (L85->83).
-
-        The inner loop's False branch for _draft_cls is taken because _FakeWritableSubSvc
-        has no _draft_cls attribute.
+        ``bad_sub`` has an unresolvable annotation and ``str_sub`` does not return a
+        PaperlessService, so both are skipped; ``writable_sub`` is registered under its
+        _resource_cls even though it has no _draft_cls.
         """
         prop = DispatchableCachedProperty(_factory_fake_with_sub_props)
-        prop.__set_name__(object, "fake_sub_prop_c")
-        assert _MODEL_TO_PROP_NAME.get(_FakeDispatchTestModel) == (
-            "fake_sub_prop_c",
-            "writable_sub",
-        )
-        del _MODEL_TO_PROP_NAME[_FakeDispatchTestModel]
+        prop.__set_name__(object, "fake_sub_prop")
+
+        assert prop._attr_name == "fake_sub_prop"
+        assert _MODEL_TO_PROP_NAME[_FakeDispatchTestModel] == ("fake_sub_prop", "writable_sub")
+        # the skipped sub-properties contributed no entry of their own
+        registered = [
+            key for key, value in _MODEL_TO_PROP_NAME.items() if value[0] == prop._attr_name
+        ]
+        assert registered == [_FakeDispatchTestModel]
 
 
 class TestDispatchGuards:
@@ -275,22 +272,20 @@ class TestDispatchGuards:
         with pytest.raises(DispatchError, match="does not support 'update'"):
             await api._dispatcher.update(note)
 
-    async def test_delete_raises_for_non_deletable_service(self, api: PaperlessClient) -> None:
+    async def test_delete_raises_for_non_deletable_service(
+        self, api: PaperlessClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """delete() must raise DispatchError when the resolved service is not DeletableService."""
-        _MODEL_TO_PROP_NAME[DocumentNote] = ("profile",)
-        try:
-            note = DocumentNote.model_construct(id=1, document=42)
-            with pytest.raises(DispatchError, match="does not support 'delete'"):
-                await api._dispatcher.delete(note)
-        finally:
-            _MODEL_TO_PROP_NAME[DocumentNote] = ("documents", "notes")
+        monkeypatch.setitem(_MODEL_TO_PROP_NAME, DocumentNote, ("profile",))
+        note = DocumentNote.model_construct(id=1, document=42)
+        with pytest.raises(DispatchError, match="does not support 'delete'"):
+            await api._dispatcher.delete(note)
 
-    async def test_save_raises_for_non_creatable_service(self, api: PaperlessClient) -> None:
+    async def test_save_raises_for_non_creatable_service(
+        self, api: PaperlessClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """save() must raise DispatchError when the resolved service is not CreatableService."""
-        _MODEL_TO_PROP_NAME[DocumentNoteDraft] = ("profile",)
-        try:
-            draft = DocumentNoteDraft.model_construct(note="x", document=42)
-            with pytest.raises(DispatchError, match="does not support 'save'"):
-                await api._dispatcher.save(draft)
-        finally:
-            _MODEL_TO_PROP_NAME[DocumentNoteDraft] = ("documents", "notes")
+        monkeypatch.setitem(_MODEL_TO_PROP_NAME, DocumentNoteDraft, ("profile",))
+        draft = DocumentNoteDraft.model_construct(note="x", document=42)
+        with pytest.raises(DispatchError, match="does not support 'save'"):
+            await api._dispatcher.save(draft)

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -101,7 +101,7 @@ class TestDocuments:
         assert document.created_date == document.created
 
     async def test_update(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-        """Updating a document PATCHes the changed field."""
+        """Updating a document PATCHes the changed field and nothing else."""
         httpx_mock.add_response(
             method="GET",
             url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_SINGLE}".format(pk=1),
@@ -117,7 +117,8 @@ class TestDocuments:
             status_code=200,
             json={**to_update.snapshot, "title": new_title},
         )
-        await paperless.documents.update(to_update)
+        assert await paperless.documents.update(to_update) is True
+        assert json.loads(httpx_mock.get_requests()[-1].content) == {"title": new_title}
         assert to_update.title == new_title
 
     async def test_delete(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
@@ -802,6 +803,14 @@ class TestDocuments:
             message="Test Message",
         )
 
+        assert json.loads(httpx_mock.get_requests()[-1].content) == {
+            "documents": [1],
+            "addresses": "test@example.org",
+            "subject": "Test Email",
+            "message": "Test Message",
+            "use_archive_version": True,
+        }
+
         httpx_mock.add_response(
             method="POST",
             url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_EMAIL}",
@@ -813,7 +822,12 @@ class TestDocuments:
                 addresses="test@example.org",
                 subject="Test Email",
                 message="Test Message",
+                use_archive_version=False,
             )
+
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["documents"] == [1, 2]
+        assert body["use_archive_version"] is False
 
     async def test_is_deleted(self, paperless: PaperlessClient) -> None:
         """Document.is_deleted is True when deleted_at is set, False otherwise."""
@@ -974,6 +988,11 @@ class TestDocumentChat:
         assert result.q == DATA_DOCUMENT_CHAT["q"]
         assert result.document_id == DATA_DOCUMENT_CHAT["document_id"]
 
+        assert json.loads(httpx_mock.get_requests()[-1].content) == {
+            "q": "What is this document about?",
+            "document_id": 1,
+        }
+
     async def test_call_without_document_id(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient
     ) -> None:
@@ -988,6 +1007,8 @@ class TestDocumentChat:
         assert isinstance(result, DocumentChat)
         assert result.q == "General question"
         assert result.document_id is None
+
+        assert json.loads(httpx_mock.get_requests()[-1].content) == {"q": "General question"}
 
 
 class TestDocumentVersionService:

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1017,7 +1017,7 @@ class TestDocumentVersionService:
     async def test_upload_via_service(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient
     ) -> None:
-        """upload() POSTs multipart data and returns None."""
+        """upload() POSTs the file as multipart and omits version_label when not given."""
         httpx_mock.add_response(
             method="POST",
             url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_UPDATE_VERSION}".format(pk=1),
@@ -1027,6 +1027,13 @@ class TestDocumentVersionService:
 
         result = await paperless.documents.versions.upload(io.BytesIO(b"data"), pk=1)
         assert result is None
+
+        request = httpx_mock.get_requests()[-1]
+        assert request.headers["content-type"].startswith("multipart/form-data")
+        body = request.content.decode(errors="replace")
+        assert 'name="document"' in body
+        assert "\r\n\r\ndata\r\n" in body
+        assert 'name="version_label"' not in body
 
     async def test_upload_with_label_via_service(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient
@@ -1043,6 +1050,9 @@ class TestDocumentVersionService:
             io.BytesIO(b"data"), version_label="v2", pk=1
         )
         assert result is None
+
+        body = httpx_mock.get_requests()[-1].content.decode(errors="replace")
+        assert re.search(r'name="version_label"\r\n\r\nv2\r\n', body) is not None
 
     async def test_update_via_service(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -4,6 +4,8 @@ import datetime
 import io
 import json
 import re
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from pytest_httpx import HTTPXMock
@@ -122,7 +124,7 @@ class TestDocuments:
         assert to_update.title == new_title
 
     async def test_delete(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-        """Deleting a document returns True on 204 and False on any other status."""
+        """delete() returns None on 204, raises DeletionError otherwise, silent_fail suppresses."""
         httpx_mock.add_response(
             method="GET",
             url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_SINGLE}".format(pk=1),
@@ -135,7 +137,22 @@ class TestDocuments:
             url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_SINGLE}".format(pk=1),
             status_code=204,
         )
-        await paperless.documents.delete(to_delete)
+        assert await paperless.documents.delete(to_delete) is None
+
+        httpx_mock.add_response(
+            method="DELETE",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_SINGLE}".format(pk=1),
+            status_code=404,
+        )
+        with pytest.raises(DeletionError):
+            await paperless.documents.delete(to_delete)
+
+        httpx_mock.add_response(
+            method="DELETE",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_SINGLE}".format(pk=1),
+            status_code=404,
+        )
+        assert await paperless.documents.delete(to_delete, silent_fail=True) is None
 
     async def test_meta(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
         """get_metadata() returns a DocumentMeta with original and archive metadata lists."""
@@ -898,17 +915,32 @@ class TestDocuments:
         assert "name" in changed
 
 
-def test_coerce_custom_fields_non_list_passthrough(api: PaperlessClient) -> None:
-    """_coerce_custom_fields must return v unchanged when v is not a list (L215)."""
-    # Pass custom_fields=None explicitly so the before-validator is triggered with a
-    # non-list value; it must return None unchanged (the field type accepts None).
-    doc = Document.from_data(api._runtime, {"id": 1, "custom_fields": None})
-    assert doc.id == 1
-    assert doc.custom_fields is None
+def _validation_info(runtime: object) -> Any:
+    """Return a stand-in carrying just the ``context`` that _enrich_from_cache reads."""
+    return SimpleNamespace(context={"runtime": runtime})
+
+
+def test_enrich_from_cache_non_list_passthrough(api: PaperlessClient) -> None:
+    """_enrich_from_cache returns non-list input unchanged instead of trying to enrich it."""
+    api.runtime.cache.custom_fields = {
+        1: CustomField.from_data(api.runtime, {"id": 1, "name": "cached", "data_type": "string"})
+    }
+    # a populated cache is what makes the enrichment loop reachable at all, so the
+    # non-list guard is the only thing keeping this from iterating a plain string
+    passthrough = DocumentCustomFieldList._enrich_from_cache(
+        "not a list", _validation_info(api.runtime)
+    )
+    assert passthrough == "not a list"
+
+
+def test_enrich_from_cache_without_cache(api: PaperlessClient) -> None:
+    """Without a populated cache the raw items are returned untouched."""
+    raw = [{"field": 1, "value": "x"}]
+    assert DocumentCustomFieldList._enrich_from_cache(raw, _validation_info(api.runtime)) is raw
 
 
 def test_document_sub_service_properties_cached(api: PaperlessClient) -> None:
-    """Accessing .history and .share_links twice returns the same object (L220->222, L234->236)."""
+    """Accessing .history and .share_links twice returns the same cached sub-service."""
     doc = Document.from_data(api._runtime, {"id": 7})
     history1 = doc.history
     history2 = doc.history

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -40,11 +40,32 @@ from pypaperless.exceptions import (
             {"detail": []},
             "Paperless [detail]: unknown error",
         ),
+        # "error" wins over the plain first-key branch even when it is not first
+        (
+            {"detail": "ignored", "error": "the real one"},
+            "Paperless [error]: the real one",
+        ),
+        # …and the generic branch picks the first key when no "error" is present
+        (
+            {"detail": "the real one", "warning": "ignored"},
+            "Paperless [detail]: the real one",
+        ),
+    ],
+    ids=[
+        "plain_string",
+        "single_key_dict",
+        "error_key_list_value",
+        "deeply_nested",
+        "empty_dict",
+        "empty_list",
+        "empty_nested_value",
+        "error_key_takes_priority",
+        "first_key_without_error",
     ],
 )
 def test_json_response_with_error_formatting(payload: object, expected_message: str) -> None:
     """JsonResponseWithError must format its message correctly for every payload shape."""
-    with pytest.raises(JsonResponseWithError, match=re.escape(expected_message)):
+    with pytest.raises(JsonResponseWithError, match=rf"^{re.escape(expected_message)}$"):
         raise JsonResponseWithError(payload)
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,7 @@
 """Tests for filter TypedDicts and typed service .filter() methods."""
 
 import re
+from typing import Any
 
 import pytest
 from pytest_httpx import HTTPXMock
@@ -24,9 +25,14 @@ from .data import (
     DATA_USERS,
 )
 
-# ---------------------------------------------------------------------------
-# Typed service .filter() acceptance
-# ---------------------------------------------------------------------------
+
+def _expected_param(value: Any) -> str:
+    """Return the query string form Paperless receives for a filter value."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list):
+        return ",".join(map(str, value))
+    return str(value)
 
 
 @pytest.mark.parametrize(
@@ -35,7 +41,7 @@ from .data import (
         (
             "documents",
             "documents",
-            {"title__icontains": "invoice", "is_tagged": True},
+            {"title__icontains": "invoice", "is_tagged": True, "id__in": [1, 2]},
             DATA_DOCUMENTS,
         ),
         ("correspondents", "correspondents", {"name__icontains": "acme"}, DATA_CORRESPONDENTS),
@@ -90,7 +96,7 @@ from .data import (
         "tasks",
     ],
 )
-async def test_service_filter_accepts_typed_kwargs(
+async def test_service_filter_forwards_typed_kwargs(
     httpx_mock: HTTPXMock,
     paperless: PaperlessClient,
     api_key: str,
@@ -98,7 +104,7 @@ async def test_service_filter_accepts_typed_kwargs(
     filter_kwargs: dict,
     mock_data: dict,
 ) -> None:
-    """service.filter() accepts typed filter kwargs and iterates results without error."""
+    """service.filter() forwards every typed filter kwarg into the query string."""
     httpx_mock.add_response(
         method="GET",
         url=re.compile(r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath[api_key.upper()]}" + r"\?.*$"),
@@ -106,5 +112,10 @@ async def test_service_filter_accepts_typed_kwargs(
         json=mock_data,
     )
     async with getattr(paperless, service_attr).filter(**filter_kwargs) as q:
-        async for item in q:
-            assert item is not None
+        items = [item async for item in q]
+
+    assert len(items) == len(mock_data["results"])
+
+    params = httpx_mock.get_requests()[-1].url.params
+    for key, value in filter_kwargs.items():
+        assert params[key] == _expected_param(value)

--- a/tests/test_fixture_data.py
+++ b/tests/test_fixture_data.py
@@ -1,0 +1,35 @@
+"""Self-checks for the snapshot fixtures in tests/data."""
+
+from typing import Any
+
+import pytest
+
+import tests.data as fixture_data
+
+
+def _paginated_fixtures() -> list[tuple[str, dict[str, Any]]]:
+    """Return every ``(name, payload)`` fixture shaped like a DRF paginated response."""
+    return [
+        (name, obj)
+        for name in sorted(fixture_data.__all__)
+        if isinstance(obj := getattr(fixture_data, name), dict)
+        and {"count", "results"} <= obj.keys()
+    ]
+
+
+def test_paginated_fixtures_discovered() -> None:
+    """The discovery must actually find fixtures, otherwise the check below is vacuous."""
+    assert len(_paginated_fixtures()) >= 15
+
+
+@pytest.mark.parametrize(
+    ("name", "payload"), _paginated_fixtures(), ids=[name for name, _ in _paginated_fixtures()]
+)
+def test_paginated_fixture_count_matches_results(name: str, payload: dict[str, Any]) -> None:
+    """A single-page fixture must report a count equal to the number of results it carries.
+
+    Tests assert item counts against ``len(results)``; a fixture whose ``count`` disagrees
+    would make ``Page.last_page`` claim pages that the fixture cannot serve.
+    """
+    assert payload["next"] is None, f"{name} is not a single-page fixture"
+    assert payload["count"] == len(payload["results"])

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,5 +1,6 @@
 """Tests for resource services: Config, Version, Profile, Statistics, Status, Tasks, Trash."""
 
+import json
 import re
 
 import pytest
@@ -120,6 +121,9 @@ async def test_profile_update(httpx_mock: HTTPXMock, paperless: PaperlessClient)
     assert profile.first_name == "Patched"
     assert profile.last_name == "User"
 
+    body = json.loads(httpx_mock.get_requests()[-1].content)
+    assert body == {"first_name": "Patched", "last_name": "User"}
+
 
 async def test_profile_update_email(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
     """profile.update(email=) PATCHes only the email field."""
@@ -134,6 +138,9 @@ async def test_profile_update_email(httpx_mock: HTTPXMock, paperless: PaperlessC
     assert isinstance(profile, Profile)
     assert profile.email == "new@example.com"
 
+    body = json.loads(httpx_mock.get_requests()[-1].content)
+    assert body == {"email": "new@example.com"}
+
 
 async def test_profile_update_password(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
     """profile.update(password=) PATCHes only the password field."""
@@ -145,6 +152,9 @@ async def test_profile_update_password(httpx_mock: HTTPXMock, paperless: Paperle
     )
     profile = await paperless.profile.update(password="s3cr3t")  # noqa: S106
     assert isinstance(profile, Profile)
+
+    body = json.loads(httpx_mock.get_requests()[-1].content)
+    assert body == {"password": "s3cr3t"}
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +336,7 @@ class TestTasks:
         )
         result = await paperless.tasks.acknowledge([1])
         assert result == 1
+        assert json.loads(httpx_mock.get_requests()[-1].content) == {"tasks": [1]}
 
     async def test_summary(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
         """tasks.summary() returns a list of TaskSummary instances."""
@@ -365,6 +376,7 @@ class TestTasks:
         result = await paperless.tasks.run("sanity_check")
         assert isinstance(result, str)
         assert result == task_uuid
+        assert json.loads(httpx_mock.get_requests()[-1].content) == {"task_type": "sanity_check"}
 
 
 # ---------------------------------------------------------------------------
@@ -396,6 +408,10 @@ class TestMailAccounts:
             json={"result": "ok"},
         )
         await paperless.mail_accounts.process(1)
+
+        request = httpx_mock.get_requests()[-1]
+        assert request.url.path.endswith("/1/process/")
+        assert json.loads(request.content) == {}
 
 
 # ---------------------------------------------------------------------------
@@ -432,7 +448,7 @@ class TestTrash:
             assert item.deleted_at is not None
 
     async def test_restore(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-        """restore() POSTs to the trash endpoint."""
+        """restore() POSTs the restore action — never the destructive empty action."""
         httpx_mock.add_response(
             method="POST",
             url=f"{PAPERLESS_TEST_URL}{EndpointPath.TRASH}",
@@ -440,6 +456,9 @@ class TestTrash:
             json={"result": "restored"},
         )
         await paperless.trash.restore([100, 101])
+
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body == {"action": "restore", "documents": [100, 101]}
 
     async def test_empty(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
         """empty() empties all or specific documents from the trash."""
@@ -451,6 +470,9 @@ class TestTrash:
         )
         await paperless.trash.empty()
 
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body == {"action": "empty"}
+
         httpx_mock.add_response(
             method="POST",
             url=f"{PAPERLESS_TEST_URL}{EndpointPath.TRASH}",
@@ -458,6 +480,9 @@ class TestTrash:
             json={"result": "emptied"},
         )
         await paperless.trash.empty([100])
+
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body == {"action": "empty", "documents": [100]}
 
 
 # ---------------------------------------------------------------------------
@@ -482,6 +507,10 @@ class TestSearch:
         assert result.documents is not None
         assert len(result.documents) == len(DATA_SEARCH["documents"])
 
+        params = httpx_mock.get_requests()[-1].url.params
+        assert params["query"] == "invoice"
+        assert "db_only" not in params
+
     async def test_call_with_db_only(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient
     ) -> None:
@@ -495,6 +524,10 @@ class TestSearch:
         result = await paperless.search("invoice", db_only=True)
         assert isinstance(result, SearchResult)
         assert result.total == DATA_SEARCH["total"]
+
+        params = httpx_mock.get_requests()[-1].url.params
+        assert params["query"] == "invoice"
+        assert params["db_only"] == "true"
 
     async def test_call_with_builder(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient
@@ -510,6 +543,8 @@ class TestSearch:
         result = await paperless.search(q)
         assert isinstance(result, SearchResult)
         assert result.total == DATA_SEARCH["total"]
+
+        assert httpx_mock.get_requests()[-1].url.params["query"] == str(q)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -18,6 +18,8 @@ from pypaperless.models import (
     ShareLinkBundle,
     Status,
     Task,
+    WorkflowAction,
+    WorkflowTrigger,
 )
 from pypaperless.models.mixins.securable import Permissions
 from pypaperless.models.tasks import TaskStatusCounts, TaskSummary
@@ -26,6 +28,8 @@ from pypaperless.models.types import (
     StatusDatabase,
     StatusStorage,
     StatusTasks,
+    WorkflowActionType,
+    WorkflowTriggerType,
 )
 from pypaperless.services.workflows import WorkflowActionService, WorkflowTriggerService
 
@@ -45,196 +49,180 @@ from .data import (
     DATA_TASKS_STATUS_COUNTS,
     DATA_TASKS_SUMMARY,
     DATA_TRASH,
+    DATA_WORKFLOW_ACTIONS,
+    DATA_WORKFLOW_TRIGGERS,
 )
 
-# ---------------------------------------------------------------------------
-# Config
-# ---------------------------------------------------------------------------
+
+class TestConfig:
+    """Config singleton service."""
+
+    async def test_config_call(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """config() fetches the singleton Config without requiring a pk."""
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.CONFIG_SINGLE}".format(pk=1),
+            status_code=200,
+            json=DATA_CONFIG[0],
+        )
+        item = await paperless.config()
+        assert isinstance(item, Config)
 
 
-async def test_config_call(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-    """config() fetches the singleton Config without requiring a pk."""
-    httpx_mock.add_response(
-        method="GET",
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.CONFIG_SINGLE}".format(pk=1),
-        status_code=200,
-        json=DATA_CONFIG[0],
-    )
-    item = await paperless.config()
-    assert item
-    assert isinstance(item, Config)
+class TestRemoteVersion:
+    """Remote version lookup service."""
+
+    async def test_remote_version_call(
+        self, httpx_mock: HTTPXMock, paperless: PaperlessClient
+    ) -> None:
+        """remote_version() returns version string and update_available flag."""
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.REMOTE_VERSION}",
+            status_code=200,
+            json=DATA_REMOTE_VERSION,
+        )
+        remote_version = await paperless.remote_version()
+        assert isinstance(remote_version.version, str)
+        assert isinstance(remote_version.update_available, bool)
 
 
-# ---------------------------------------------------------------------------
-# Remote version
-# ---------------------------------------------------------------------------
+class TestProfile:
+    """Profile service: read and partial updates."""
+
+    async def test_profile_call(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """profile() returns a Profile with expected field types."""
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.PROFILE}",
+            status_code=200,
+            json=DATA_PROFILE,
+        )
+        profile = await paperless.profile()
+        assert isinstance(profile, Profile)
+        assert isinstance(profile.email, str)
+        assert isinstance(profile.auth_token, str)
+        assert isinstance(profile.has_usable_password, bool)
+        assert isinstance(profile.is_mfa_enabled, bool)
+        assert isinstance(profile.social_accounts, list)
+
+    async def test_profile_update(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """profile.update() PATCHes the profile and returns the updated model."""
+        updated = {**DATA_PROFILE, "first_name": "Patched", "last_name": "User"}
+        httpx_mock.add_response(
+            method="PATCH",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.PROFILE}",
+            status_code=200,
+            json=updated,
+        )
+        profile = await paperless.profile.update(first_name="Patched", last_name="User")
+        assert isinstance(profile, Profile)
+        assert profile.first_name == "Patched"
+        assert profile.last_name == "User"
+
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body == {"first_name": "Patched", "last_name": "User"}
+
+    async def test_profile_update_email(
+        self, httpx_mock: HTTPXMock, paperless: PaperlessClient
+    ) -> None:
+        """profile.update(email=) PATCHes only the email field."""
+        updated = {**DATA_PROFILE, "email": "new@example.com"}
+        httpx_mock.add_response(
+            method="PATCH",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.PROFILE}",
+            status_code=200,
+            json=updated,
+        )
+        profile = await paperless.profile.update(email="new@example.com")
+        assert isinstance(profile, Profile)
+        assert profile.email == "new@example.com"
+
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body == {"email": "new@example.com"}
+
+    async def test_profile_update_password(
+        self, httpx_mock: HTTPXMock, paperless: PaperlessClient
+    ) -> None:
+        """profile.update(password=) PATCHes only the password field."""
+        httpx_mock.add_response(
+            method="PATCH",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.PROFILE}",
+            status_code=200,
+            json=DATA_PROFILE,
+        )
+        profile = await paperless.profile.update(password="s3cr3t")
+        assert isinstance(profile, Profile)
+
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body == {"password": "s3cr3t"}
 
 
-async def test_remote_version_call(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-    """remote_version() returns version string and update_available flag."""
-    httpx_mock.add_response(
-        method="GET",
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.REMOTE_VERSION}",
-        status_code=200,
-        json=DATA_REMOTE_VERSION,
-    )
-    remote_version = await paperless.remote_version()
-    assert remote_version
-    assert isinstance(remote_version.version, str)
-    assert isinstance(remote_version.update_available, bool)
+class TestStatistics:
+    """Statistics service."""
+
+    async def test_statistics_call(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """statistics() returns typed statistics with document file type counts."""
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.STATISTICS}",
+            status_code=200,
+            json=DATA_STATISTICS,
+        )
+        stats = await paperless.statistics()
+        assert isinstance(stats.character_count, int)
+        assert isinstance(stats.document_file_type_counts, list)
+        for item in stats.document_file_type_counts:
+            assert isinstance(item, StatisticDocumentFileTypeCount)
 
 
-# ---------------------------------------------------------------------------
-# Profile
-# ---------------------------------------------------------------------------
+class TestStatus:
+    """System status service and the has_errors aggregation."""
 
+    async def test_status_call(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """status() returns a Status with typed sub-objects."""
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.STATUS}",
+            status_code=200,
+            json=DATA_STATUS,
+        )
+        status = await paperless.status()
+        assert isinstance(status, Status)
+        assert isinstance(status.storage, StatusStorage)
+        assert isinstance(status.database, StatusDatabase)
+        assert isinstance(status.tasks, StatusTasks)
 
-async def test_profile_call(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-    """profile() returns a Profile with expected field types."""
-    httpx_mock.add_response(
-        method="GET",
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.PROFILE}",
-        status_code=200,
-        json=DATA_PROFILE,
-    )
-    profile = await paperless.profile()
-    assert profile
-    assert isinstance(profile, Profile)
-    assert isinstance(profile.email, str)
-    assert isinstance(profile.auth_token, str)
-    assert isinstance(profile.has_usable_password, bool)
-    assert isinstance(profile.is_mfa_enabled, bool)
-    assert isinstance(profile.social_accounts, list)
+    async def test_status_has_errors(self, paperless: PaperlessClient) -> None:
+        """Status.has_errors is True when any component is in ERROR state."""
+        data = {
+            "database": {"status": "OK"},
+            "tasks": {
+                "redis_status": "OK",
+                "celery_status": "OK",
+                "classifier_status": "OK",
+            },
+        }
+        status = Status.from_data(paperless.runtime, data=data)
+        assert status.has_errors is False
 
+        data["database"]["status"] = "ERROR"
+        status = Status.from_data(paperless.runtime, data=data)
+        assert status.has_errors is True
 
-async def test_profile_update(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-    """profile.update() PATCHes the profile and returns the updated model."""
-    updated = {**DATA_PROFILE, "first_name": "Patched", "last_name": "User"}
-    httpx_mock.add_response(
-        method="PATCH",
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.PROFILE}",
-        status_code=200,
-        json=updated,
-    )
-    profile = await paperless.profile.update(first_name="Patched", last_name="User")
-    assert isinstance(profile, Profile)
-    assert profile.first_name == "Patched"
-    assert profile.last_name == "User"
+        # None values are treated as no errors
+        del data["database"]["status"]
+        status = Status.from_data(paperless.runtime, data=data)
+        assert status.has_errors is False
 
-    body = json.loads(httpx_mock.get_requests()[-1].content)
-    assert body == {"first_name": "Patched", "last_name": "User"}
+    def test_status_has_errors_no_tasks(self, paperless: PaperlessClient) -> None:
+        """has_errors must work when tasks is None, skipping the per-task status extend."""
+        status = Status.from_data(paperless.runtime, data={"database": {"status": "OK"}})
+        assert status.tasks is None
+        assert status.has_errors is False
 
-
-async def test_profile_update_email(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-    """profile.update(email=) PATCHes only the email field."""
-    updated = {**DATA_PROFILE, "email": "new@example.com"}
-    httpx_mock.add_response(
-        method="PATCH",
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.PROFILE}",
-        status_code=200,
-        json=updated,
-    )
-    profile = await paperless.profile.update(email="new@example.com")
-    assert isinstance(profile, Profile)
-    assert profile.email == "new@example.com"
-
-    body = json.loads(httpx_mock.get_requests()[-1].content)
-    assert body == {"email": "new@example.com"}
-
-
-async def test_profile_update_password(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-    """profile.update(password=) PATCHes only the password field."""
-    httpx_mock.add_response(
-        method="PATCH",
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.PROFILE}",
-        status_code=200,
-        json=DATA_PROFILE,
-    )
-    profile = await paperless.profile.update(password="s3cr3t")  # noqa: S106
-    assert isinstance(profile, Profile)
-
-    body = json.loads(httpx_mock.get_requests()[-1].content)
-    assert body == {"password": "s3cr3t"}
-
-
-# ---------------------------------------------------------------------------
-# Statistics
-# ---------------------------------------------------------------------------
-
-
-async def test_statistics_call(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-    """statistics() returns typed statistics with document file type counts."""
-    httpx_mock.add_response(
-        method="GET",
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.STATISTICS}",
-        status_code=200,
-        json=DATA_STATISTICS,
-    )
-    stats = await paperless.statistics()
-    assert stats
-    assert isinstance(stats.character_count, int)
-    assert isinstance(stats.document_file_type_counts, list)
-    for item in stats.document_file_type_counts:
-        assert isinstance(item, StatisticDocumentFileTypeCount)
-
-
-# ---------------------------------------------------------------------------
-# Status
-# ---------------------------------------------------------------------------
-
-
-async def test_status_call(httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
-    """status() returns a Status with typed sub-objects."""
-    httpx_mock.add_response(
-        method="GET",
-        url=f"{PAPERLESS_TEST_URL}{EndpointPath.STATUS}",
-        status_code=200,
-        json=DATA_STATUS,
-    )
-    status = await paperless.status()
-    assert status
-    assert isinstance(status, Status)
-    assert isinstance(status.storage, StatusStorage)
-    assert isinstance(status.database, StatusDatabase)
-    assert isinstance(status.tasks, StatusTasks)
-
-
-async def test_status_has_errors(paperless: PaperlessClient) -> None:
-    """Status.has_errors is True when any component is in ERROR state."""
-    data = {
-        "database": {"status": "OK"},
-        "tasks": {
-            "redis_status": "OK",
-            "celery_status": "OK",
-            "classifier_status": "OK",
-        },
-    }
-    status = Status.from_data(paperless.runtime, data=data)
-    assert status.has_errors is False
-
-    data["database"]["status"] = "ERROR"
-    status = Status.from_data(paperless.runtime, data=data)
-    assert status.has_errors is True
-
-    # None values are treated as no errors
-    del data["database"]["status"]
-    status = Status.from_data(paperless.runtime, data=data)
-    assert status.has_errors is False
-
-
-def test_status_has_errors_no_tasks(paperless: PaperlessClient) -> None:
-    """has_errors must work when tasks is None (skips the tasks extend, L91->100)."""
-    status = Status.from_data(paperless.runtime, data={"database": {"status": "OK"}})
-    assert status.tasks is None
-    assert status.has_errors is False
-
-    status_err = Status.from_data(paperless.runtime, data={"database": {"status": "ERROR"}})
-    assert status_err.has_errors is True
-
-
-# ---------------------------------------------------------------------------
-# Tasks
-# ---------------------------------------------------------------------------
+        status_err = Status.from_data(paperless.runtime, data={"database": {"status": "ERROR"}})
+        assert status_err.has_errors is True
 
 
 class TestTasks:
@@ -279,7 +267,6 @@ class TestTasks:
             json=DATA_TASKS["results"][0],
         )
         item = await paperless.tasks(1)
-        assert item
         assert isinstance(item, Task)
 
     async def test_call_by_uuid(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
@@ -291,7 +278,6 @@ class TestTasks:
             json=DATA_TASKS,
         )
         item = await paperless.tasks("dummy-found")
-        assert item
         assert isinstance(item, Task)
 
     async def test_call_pk_not_found(
@@ -386,11 +372,6 @@ class TestTasks:
         assert json.loads(httpx_mock.get_requests()[-1].content) == {"task_type": "sanity_check"}
 
 
-# ---------------------------------------------------------------------------
-# Mail Accounts
-# ---------------------------------------------------------------------------
-
-
 class TestMailAccounts:
     """Mail account service action endpoints."""
 
@@ -421,20 +402,75 @@ class TestMailAccounts:
         assert json.loads(request.content) == {}
 
 
-# ---------------------------------------------------------------------------
-# Workflows
-# ---------------------------------------------------------------------------
+class TestWorkflows:
+    """Workflow service and its action / trigger sub-services."""
 
+    async def test_sub_services(self, paperless: PaperlessClient) -> None:
+        """workflows.actions and workflows.triggers are the expected service types."""
+        assert isinstance(paperless.workflows.actions, WorkflowActionService)
+        assert isinstance(paperless.workflows.triggers, WorkflowTriggerService)
 
-async def test_workflow_sub_services(paperless: PaperlessClient) -> None:
-    """workflows.actions and workflows.triggers are the expected service types."""
-    assert isinstance(paperless.workflows.actions, WorkflowActionService)
-    assert isinstance(paperless.workflows.triggers, WorkflowTriggerService)
+    async def test_actions_iter(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """Iterating workflows.actions yields WorkflowAction instances."""
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(
+                r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.WORKFLOW_ACTIONS}" + r"\?.*$"
+            ),
+            status_code=200,
+            json=DATA_WORKFLOW_ACTIONS,
+        )
+        items = [item async for item in paperless.workflows.actions]
+        assert len(items) == len(DATA_WORKFLOW_ACTIONS["results"])
+        for item in items:
+            assert isinstance(item, WorkflowAction)
+            assert isinstance(item.type, WorkflowActionType)
 
+    async def test_actions_call(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """workflows.actions(pk) fetches a single action by primary key."""
+        action = DATA_WORKFLOW_ACTIONS["results"][0]
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.WORKFLOW_ACTIONS_SINGLE}".format(
+                pk=action["id"]
+            ),
+            status_code=200,
+            json=action,
+        )
+        item = await paperless.workflows.actions(action["id"])
+        assert isinstance(item, WorkflowAction)
+        assert item.id == action["id"]
 
-# ---------------------------------------------------------------------------
-# Trash
-# ---------------------------------------------------------------------------
+    async def test_triggers_iter(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """Iterating workflows.triggers yields WorkflowTrigger instances."""
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(
+                r"^" + f"{PAPERLESS_TEST_URL}{EndpointPath.WORKFLOW_TRIGGERS}" + r"\?.*$"
+            ),
+            status_code=200,
+            json=DATA_WORKFLOW_TRIGGERS,
+        )
+        items = [item async for item in paperless.workflows.triggers]
+        assert len(items) == len(DATA_WORKFLOW_TRIGGERS["results"])
+        for item in items:
+            assert isinstance(item, WorkflowTrigger)
+            assert isinstance(item.type, WorkflowTriggerType)
+
+    async def test_triggers_call(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
+        """workflows.triggers(pk) fetches a single trigger by primary key."""
+        trigger = DATA_WORKFLOW_TRIGGERS["results"][0]
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{PAPERLESS_TEST_URL}{EndpointPath.WORKFLOW_TRIGGERS_SINGLE}".format(
+                pk=trigger["id"]
+            ),
+            status_code=200,
+            json=trigger,
+        )
+        item = await paperless.workflows.triggers(trigger["id"])
+        assert isinstance(item, WorkflowTrigger)
+        assert item.id == trigger["id"]
 
 
 class TestTrash:
@@ -490,11 +526,6 @@ class TestTrash:
 
         body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body == {"action": "empty", "documents": [100]}
-
-
-# ---------------------------------------------------------------------------
-# Search
-# ---------------------------------------------------------------------------
 
 
 class TestSearch:
@@ -554,11 +585,6 @@ class TestSearch:
         assert httpx_mock.get_requests()[-1].url.params["query"] == str(q)
 
 
-# ---------------------------------------------------------------------------
-# BulkEditObjects
-# ---------------------------------------------------------------------------
-
-
 class TestBulkEditObjects:
     """BulkEditObjects service: set_permissions and delete operations."""
 
@@ -580,7 +606,7 @@ class TestBulkEditObjects:
         assert result is None
 
         request = httpx_mock.get_requests()[-1]
-        body = __import__("json").loads(request.content)
+        body = json.loads(request.content)
         assert body["object_type"] == "tags"
         assert body["operation"] == "set_permissions"
         assert body["objects"] == [1, 2, 3]
@@ -600,7 +626,7 @@ class TestBulkEditObjects:
         await paperless.bulk_edit_objects.set_permissions("correspondents", [7])
 
         request = httpx_mock.get_requests()[-1]
-        body = __import__("json").loads(request.content)
+        body = json.loads(request.content)
         assert "owner" not in body
         assert "permissions" not in body
         assert body["merge"] is False
@@ -617,15 +643,10 @@ class TestBulkEditObjects:
         assert result is None
 
         request = httpx_mock.get_requests()[-1]
-        body = __import__("json").loads(request.content)
+        body = json.loads(request.content)
         assert body["object_type"] == "document_types"
         assert body["operation"] == "delete"
         assert body["objects"] == [10, 11]
-
-
-# ---------------------------------------------------------------------------
-# DocumentsBulkEdit
-# ---------------------------------------------------------------------------
 
 
 class TestDocumentsBulkEdit:
@@ -642,7 +663,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.set_correspondent([1, 2], 5)
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["method"] == "set_correspondent"
         assert body["documents"] == [1, 2]
         assert body["parameters"]["correspondent"] == 5
@@ -658,7 +679,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.set_document_type([3], 7)
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["method"] == "set_document_type"
         assert body["parameters"]["document_type"] == 7
 
@@ -673,7 +694,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.set_storage_path([4, 5], 2)
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["method"] == "set_storage_path"
         assert body["parameters"]["storage_path"] == 2
 
@@ -686,7 +707,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.add_tag([1], 10)
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["method"] == "add_tag"
         assert body["parameters"]["tag"] == 10
 
@@ -699,7 +720,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.remove_tag([1], 10)
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["method"] == "remove_tag"
         assert body["parameters"]["tag"] == 10
 
@@ -712,7 +733,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.modify_tags([1], add_tags=[3, 4], remove_tags=[5])
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["method"] == "modify_tags"
         assert body["parameters"]["add_tags"] == [3, 4]
         assert body["parameters"]["remove_tags"] == [5]
@@ -730,7 +751,7 @@ class TestDocumentsBulkEdit:
         await paperless.documents.bulk_edit.modify_custom_fields(
             [1], add_custom_fields={1: "value"}, remove_custom_fields=[2]
         )
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["method"] == "modify_custom_fields"
         assert body["parameters"]["add_custom_fields"] == {"1": "value"}
         assert body["parameters"]["remove_custom_fields"] == [2]
@@ -747,7 +768,7 @@ class TestDocumentsBulkEdit:
         await paperless.documents.bulk_edit.set_permissions(
             [1, 2], owner=5, permissions=perms, merge=True
         )
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["method"] == "set_permissions"
         assert body["parameters"]["owner"] == 5
         assert body["parameters"]["merge"] is True
@@ -762,7 +783,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.delete([1, 2])
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["documents"] == [1, 2]
 
     async def test_reprocess(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
@@ -774,7 +795,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.reprocess([1])
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["documents"] == [1]
 
     async def test_rotate(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
@@ -786,7 +807,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.rotate([1, 2], 90)
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["degrees"] == 90
         assert body["source_mode"] == "latest_version"
 
@@ -801,7 +822,7 @@ class TestDocumentsBulkEdit:
         await paperless.documents.bulk_edit.merge(
             [1, 2], metadata_document_id=1, delete_originals=True
         )
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["documents"] == [1, 2]
         assert body["metadata_document_id"] == 1
         assert body["delete_originals"] is True
@@ -816,7 +837,7 @@ class TestDocumentsBulkEdit:
         )
         ops = [{"page": 1, "rotate": 90}]
         await paperless.documents.bulk_edit.edit_pdf(42, ops)
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["documents"] == [42]
         assert body["operations"] == ops
         assert body["include_metadata"] is True
@@ -830,7 +851,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.remove_password([5], "s3cr3t")
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["documents"] == [5]
         assert body["password"] == "s3cr3t"
         assert body["source_mode"] == "latest_version"
@@ -838,7 +859,7 @@ class TestDocumentsBulkEdit:
     async def test_set_permissions_no_owner_no_permissions(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient
     ) -> None:
-        """set_permissions() omits owner/set_permissions when not given (L235->237, L237->239)."""
+        """set_permissions() omits owner/set_permissions when not given."""
         httpx_mock.add_response(
             method="POST",
             url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_BULK_EDIT}",
@@ -846,7 +867,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.set_permissions([1, 2], merge=False)
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["method"] == "set_permissions"
         assert "owner" not in body["parameters"]
         assert "set_permissions" not in body["parameters"]
@@ -854,7 +875,7 @@ class TestDocumentsBulkEdit:
     async def test_merge_no_metadata_document_id(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient
     ) -> None:
-        """merge() must omit metadata_document_id when not provided (L336->338)."""
+        """merge() must omit metadata_document_id when not provided."""
         httpx_mock.add_response(
             method="POST",
             url=f"{PAPERLESS_TEST_URL}{EndpointPath.DOCUMENTS_MERGE}",
@@ -862,7 +883,7 @@ class TestDocumentsBulkEdit:
             json=DATA_DOCUMENTS_BULK_EDIT,
         )
         await paperless.documents.bulk_edit.merge([1, 2])
-        body = __import__("json").loads(httpx_mock.get_requests()[-1].content)
+        body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["documents"] == [1, 2]
         assert "metadata_document_id" not in body
 
@@ -878,11 +899,6 @@ class TestDocumentsBulkEdit:
         )
         with pytest.raises(BulkEditError):
             await paperless.documents.bulk_edit.modify_tags([1], add_tags=[3], remove_tags=[])
-
-
-# ---------------------------------------------------------------------------
-# ShareLinkBundles
-# ---------------------------------------------------------------------------
 
 
 class TestShareLinkBundleRebuild:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -248,7 +248,9 @@ class TestTasks:
             status_code=200,
             json=DATA_TASKS,
         )
-        async for item in paperless.tasks:
+        items = [item async for item in paperless.tasks]
+        assert len(items) == len(DATA_TASKS["results"])
+        for item in items:
             assert isinstance(item, Task)
 
     async def test_filter(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
@@ -260,8 +262,13 @@ class TestTasks:
             json=DATA_TASKS,
         )
         async with paperless.tasks.filter(status=["pending"]) as filtered:
-            async for item in filtered:
-                assert isinstance(item, Task)
+            items = [item async for item in filtered]
+
+        assert len(items) == len(DATA_TASKS["results"])
+        for item in items:
+            assert isinstance(item, Task)
+        # a plain list filter is sent as repeated params, unlike __in/__all
+        assert httpx_mock.get_requests()[-1].url.params.get_list("status") == ["pending"]
 
     async def test_call_by_pk(self, httpx_mock: HTTPXMock, paperless: PaperlessClient) -> None:
         """tasks(pk) fetches by primary key."""

--- a/tests/test_search_builder.py
+++ b/tests/test_search_builder.py
@@ -3,10 +3,6 @@
 from pypaperless.builders import SearchQuery
 from pypaperless.builders.search import _SearchQueryAnd, _SearchQueryNot, _SearchQueryOr
 
-# ---------------------------------------------------------------------------
-# Atom
-# ---------------------------------------------------------------------------
-
 
 def test_atom_build() -> None:
     """A plain atom builds to its term string."""
@@ -20,11 +16,6 @@ def test_atom_repr() -> None:
     q = SearchQuery("invoice")
     assert "SearchQuery" in repr(q)
     assert "invoice" in repr(q)
-
-
-# ---------------------------------------------------------------------------
-# Factory class-methods
-# ---------------------------------------------------------------------------
 
 
 def test_field_factory() -> None:
@@ -43,11 +34,6 @@ def test_date_range_factory() -> None:
     assert str(q2) == "added:[yesterday to today]"
 
 
-# ---------------------------------------------------------------------------
-# AND
-# ---------------------------------------------------------------------------
-
-
 def test_and_operator() -> None:
     """``&`` combines two atoms into a _SearchQueryAnd."""
     q = SearchQuery("invoice") & SearchQuery.field("tag", "unpaid")
@@ -60,11 +46,6 @@ def test_and_flatten() -> None:
     q = SearchQuery("a") & SearchQuery("b") & SearchQuery("c")
     assert isinstance(q, _SearchQueryAnd)
     assert str(q) == "(a AND b AND c)"
-
-
-# ---------------------------------------------------------------------------
-# OR
-# ---------------------------------------------------------------------------
 
 
 def test_or_operator() -> None:
@@ -81,21 +62,11 @@ def test_or_flatten() -> None:
     assert str(q) == "(a OR b OR c)"
 
 
-# ---------------------------------------------------------------------------
-# NOT
-# ---------------------------------------------------------------------------
-
-
 def test_not_operator() -> None:
     """``~`` wraps an atom into a _SearchQueryNot."""
     q = ~SearchQuery.field("document_type", "letter")
     assert isinstance(q, _SearchQueryNot)
     assert str(q) == "NOT document_type:letter"
-
-
-# ---------------------------------------------------------------------------
-# Tantivy field renames and new JSON sub-fields
-# ---------------------------------------------------------------------------
 
 
 def test_renamed_fields() -> None:
@@ -116,3 +87,44 @@ def test_custom_fields_subfields() -> None:
     """JSON sub-field syntax for custom_fields produces the correct dotted terms."""
     assert str(SearchQuery.field("custom_fields.value", "42")) == "custom_fields.value:42"
     assert str(SearchQuery.field("custom_fields.name", "amount")) == "custom_fields.name:amount"
+
+
+def test_mixed_and_or_keeps_precedence_explicit() -> None:
+    """A nested OR inside an AND stays parenthesised instead of flattening."""
+    q = SearchQuery("invoice") & (
+        SearchQuery.field("tag", "unpaid") | SearchQuery.field("tag", "overdue")
+    )
+    assert isinstance(q, _SearchQueryAnd)
+    assert str(q) == "(invoice AND (tag:unpaid OR tag:overdue))"
+
+
+def test_mixed_or_and_keeps_precedence_explicit() -> None:
+    """A nested AND inside an OR stays parenthesised instead of flattening."""
+    q = SearchQuery.field("tag", "inbox") | (
+        SearchQuery("invoice") & SearchQuery.field("correspondent", "acme")
+    )
+    assert isinstance(q, _SearchQueryOr)
+    assert str(q) == "(tag:inbox OR (invoice AND correspondent:acme))"
+
+
+def test_not_of_compound_wraps_the_whole_group() -> None:
+    """~ applied to a compound negates the entire group, not just its first operand."""
+    q = ~(SearchQuery.field("tag", "inbox") & SearchQuery.field("tag", "unpaid"))
+    assert isinstance(q, _SearchQueryNot)
+    assert str(q) == "NOT (tag:inbox AND tag:unpaid)"
+
+
+def test_and_or_not_composition() -> None:
+    """AND, OR and NOT compose into one expression with the intended grouping."""
+    q = (SearchQuery("invoice") | SearchQuery("receipt")) & ~SearchQuery.field(
+        "document_type", "letter"
+    )
+    assert isinstance(q, _SearchQueryAnd)
+    assert str(q) == "((invoice OR receipt) AND NOT document_type:letter)"
+
+
+def test_flatten_only_applies_to_the_same_operator() -> None:
+    """Chaining AND across an OR operand keeps the OR as a single nested operand."""
+    q = SearchQuery("a") & (SearchQuery("b") | SearchQuery("c")) & SearchQuery("d")
+    assert isinstance(q, _SearchQueryAnd)
+    assert str(q) == "(a AND (b OR c) AND d)"

--- a/tests/test_service_mixins.py
+++ b/tests/test_service_mixins.py
@@ -241,11 +241,12 @@ class TestReadWrite(_SharedServiceTests):
         update_value = mapping.update_value
         pk = mapping.data["results"][0]["id"]
         service = getattr(paperless, mapping.resource)
+        single_url = (
+            f"{PAPERLESS_TEST_URL}{EndpointPath[(mapping.resource + '_single').upper()]}"
+        ).format(pk=pk)
         httpx_mock.add_response(
             method="GET",
-            url=(
-                f"{PAPERLESS_TEST_URL}{EndpointPath[(mapping.resource + '_single').upper()]}"
-            ).format(pk=pk),
+            url=single_url,
             status_code=200,
             json=mapping.data["results"][0],
         )
@@ -253,27 +254,27 @@ class TestReadWrite(_SharedServiceTests):
         setattr(to_update, update_field, update_value)
         httpx_mock.add_response(
             method="PATCH",
-            url=(
-                f"{PAPERLESS_TEST_URL}{EndpointPath[(mapping.resource + '_single').upper()]}"
-            ).format(pk=pk),
+            url=single_url,
             status_code=200,
             json={**to_update.snapshot, update_field: update_value},
         )
-        await service.update(to_update)
-        assert getattr(to_update, update_field) == update_value
-        # no-op update
-        assert not await service.update(to_update)
+        assert await service.update(to_update) is True
+        assert json_mod.loads(httpx_mock.get_requests()[-1].content) == {update_field: update_value}
+        # no-op update must not hit the API at all
+        sent = len(httpx_mock.get_requests())
+        assert await service.update(to_update) is False
+        assert len(httpx_mock.get_requests()) == sent
         # force full update
         setattr(to_update, update_field, update_value)
         httpx_mock.add_response(
             method="PUT",
-            url=(
-                f"{PAPERLESS_TEST_URL}{EndpointPath[(mapping.resource + '_single').upper()]}"
-            ).format(pk=pk),
+            url=single_url,
             status_code=200,
             json={**to_update.snapshot, update_field: update_value},
         )
-        await service.update(to_update, only_changed=False)
+        expected_full = to_update.api_dump()
+        assert await service.update(to_update, only_changed=False) is True
+        assert json_mod.loads(httpx_mock.get_requests()[-1].content) == expected_full
         assert getattr(to_update, update_field) == update_value
 
     async def test_delete(
@@ -354,6 +355,7 @@ class TestSecurableService:
             json={**mapping.data["results"][0], "permissions": DATA_OBJECT_PERMISSIONS},
         )
         item = await getattr(paperless, mapping.resource)(1)
+        assert httpx_mock.get_requests()[-1].url.params["full_perms"] == "true"
         assert item.has_permissions
         assert isinstance(item.permissions, Permissions)
         # iterator with permissions
@@ -373,7 +375,10 @@ class TestSecurableService:
                 ],
             },
         )
-        async for item in getattr(paperless, mapping.resource):
+        items = [item async for item in getattr(paperless, mapping.resource)]
+        assert httpx_mock.get_requests()[-1].url.params["full_perms"] == "true"
+        assert len(items) == len(mapping.data["results"])
+        for item in items:
             assert isinstance(item, mapping.model_cls)
             assert item.has_permissions
             assert isinstance(item.permissions, Permissions)

--- a/tests/test_service_mixins.py
+++ b/tests/test_service_mixins.py
@@ -11,8 +11,9 @@ from pytest_httpx import HTTPXMock
 from pypaperless import PaperlessClient
 from pypaperless.const import EndpointPath
 from pypaperless.exceptions import DeletionError, DraftFieldRequiredError, NotFoundError
-from pypaperless.models import Page
+from pypaperless.models import Page, Tag
 from pypaperless.models.base import PaperlessModel
+from pypaperless.models.mixins.data_fields import MatchingAlgorithm
 from pypaperless.models.types import Permissions
 from pypaperless.services import mixins as svc_mixins
 from pypaperless.services.base import ResourceService
@@ -95,7 +96,6 @@ class _SharedServiceTests:
             json=mapping.data["results"][0],
         )
         item = await getattr(paperless, mapping.resource)(1)
-        assert item
         assert isinstance(item, mapping.model_cls)
         # must raise as 1337 doesn't exist
         httpx_mock.add_response(
@@ -468,11 +468,6 @@ class TestSecurableService:
         assert not service.request_permissions
 
 
-# ---------------------------------------------------------------------------
-# Standalone model / mixin unit tests
-# ---------------------------------------------------------------------------
-
-
 def test_permissions_from_existing_instance() -> None:
     """Permissions._accept_flat passes through non-dict input (e.g. an existing instance)."""
     # Call _accept_flat directly with a non-dict value — it must return it unchanged
@@ -565,3 +560,46 @@ async def test_filter_contexts_isolated_across_tasks(
 
     sent = {req.url.params["name__icontains"] for req in httpx_mock.get_requests()[-2:]}
     assert sent == {"acme", "globex"}
+
+
+def test_tag_with_nested_children(api: PaperlessClient) -> None:
+    """Tag._validate_children builds nested Tag instances from raw dict children."""
+    tag_data = {
+        "id": 1,
+        "slug": "parent",
+        "name": "Parent Tag",
+        "color": "#000000",
+        "text_color": "#ffffff",
+        "matching_algorithm": 2,
+        "children": [
+            {
+                "id": 2,
+                "slug": "child",
+                "name": "Child Tag",
+                "color": "#000000",
+                "text_color": "#ffffff",
+                "matching_algorithm": 1,
+                "children": [
+                    {
+                        "id": 3,
+                        "slug": "grandchild",
+                        "name": "Grandchild Tag",
+                        "color": "#000000",
+                        "text_color": "#ffffff",
+                        "matching_algorithm": 6,
+                    }
+                ],
+            }
+        ],
+    }
+    tag = Tag.from_data(api._runtime, data=tag_data)
+    assert tag.name == "Parent Tag"
+    assert isinstance(tag.children, list)
+    child = tag.children[0]
+    assert isinstance(child, Tag)
+    assert child.name == "Child Tag"
+    assert child.matching_algorithm == MatchingAlgorithm.ANY
+    assert isinstance(child.children, list)
+    assert isinstance(child.children[0], Tag)
+    assert child.children[0].name == "Grandchild Tag"
+    assert child.children[0].matching_algorithm == MatchingAlgorithm.AUTO

--- a/tests/test_service_mixins.py
+++ b/tests/test_service_mixins.py
@@ -59,6 +59,7 @@ class _SharedServiceTests:
         page = await anext(aiter(getattr(paperless, mapping.resource).pages(1)))
         assert isinstance(page, Page)
         assert isinstance(page.items, list)
+        assert len(page.items) == len(mapping.data["results"])
         for item in page.items:
             assert isinstance(item, mapping.model_cls)
 
@@ -76,7 +77,9 @@ class _SharedServiceTests:
             status_code=200,
             json=mapping.data,
         )
-        async for item in getattr(paperless, mapping.resource):
+        items = [item async for item in getattr(paperless, mapping.resource)]
+        assert len(items) == len(mapping.data["results"])
+        for item in items:
             assert isinstance(item, mapping.model_cls)
 
     async def test_call(
@@ -145,6 +148,7 @@ class TestReadOnly(_SharedServiceTests):
             json=mapping.data,
         )
         items = await getattr(paperless, mapping.resource).as_dict()
+        assert set(items) == {entry["id"] for entry in mapping.data["results"]}
         for pk, obj in items.items():
             assert isinstance(pk, int)
             assert isinstance(obj, mapping.model_cls)
@@ -164,6 +168,7 @@ class TestReadOnly(_SharedServiceTests):
             json=mapping.data,
         )
         items = await getattr(paperless, mapping.resource).as_list()
+        assert len(items) == len(mapping.data["results"])
         for obj in items:
             assert isinstance(obj, mapping.model_cls)
 
@@ -203,8 +208,16 @@ class TestReadWrite(_SharedServiceTests):
             any_filter_list__in=["1", "2"],
             any_filter_no_list__in="1",
         ) as q:
-            async for item in q:
-                assert isinstance(item, mapping.model_cls)
+            items = [item async for item in q]
+
+        assert len(items) == len(mapping.data["results"])
+        for item in items:
+            assert isinstance(item, mapping.model_cls)
+
+        params = httpx_mock.get_requests()[-1].url.params
+        assert params["any_filter_param"] == "1"
+        assert params["any_filter_list__in"] == "1,2"
+        assert params["any_filter_no_list__in"] == "1"
 
     async def test_create(
         self, httpx_mock: HTTPXMock, paperless: PaperlessClient, mapping: ResourceTestMapping

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,91 +1,64 @@
 """Tests for enum types: UNKNOWN fallback values."""
 
-from typing import Any
+import importlib
+import inspect
+import pkgutil
+from enum import Enum
 
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
-from pypaperless.const import PaperlessResource
+import pypaperless
 from pypaperless.models.saved_views import _DisplayFieldValue
 from pypaperless.models.types import (
-    CustomFieldType,
-    ImapSecurity,
-    MailAccountType,
-    MailRuleAction,
-    MailRuleAttachmentType,
-    MailRuleConsumptionScope,
-    MailRuleCorrespondentSource,
-    MailRulePdfLayout,
-    MailRuleTitleSource,
-    MatchingAlgorithm,
-    OutputType,
     SavedViewCustomFieldDisplay,
     SavedViewDisplayField,
-    SavedViewDisplayMode,
-    ShareLinkFileVersion,
-    StatusType,
-    TaskStatus,
-    TaskType,
-    WorkflowActionType,
-    WorkflowTriggerScheduleDateField,
-    WorkflowTriggerSource,
-    WorkflowTriggerType,
 )
 
 _NEVER_STR = "!never_existing_type!"
 _NEVER_INT = 99952342
 
 
-@pytest.mark.parametrize(
-    ("enum_cls", "bad_value"),
-    [
-        (PaperlessResource, _NEVER_STR),
-        (CustomFieldType, _NEVER_STR),
-        (MatchingAlgorithm, _NEVER_INT),
-        (ShareLinkFileVersion, _NEVER_STR),
-        (StatusType, _NEVER_STR),
-        (TaskType, _NEVER_STR),
-        (TaskStatus, _NEVER_STR),
-        (WorkflowActionType, _NEVER_INT),
-        (WorkflowTriggerType, _NEVER_INT),
-        (WorkflowTriggerScheduleDateField, _NEVER_STR),
-        (WorkflowTriggerSource, _NEVER_INT),
-        (OutputType, _NEVER_STR),
-        (SavedViewDisplayMode, _NEVER_STR),
-        (ImapSecurity, _NEVER_INT),
-        (MailAccountType, _NEVER_INT),
-        (MailRuleAction, _NEVER_INT),
-        (MailRuleTitleSource, _NEVER_INT),
-        (MailRuleCorrespondentSource, _NEVER_INT),
-        (MailRuleAttachmentType, _NEVER_INT),
-        (MailRuleConsumptionScope, _NEVER_INT),
-        (MailRulePdfLayout, _NEVER_INT),
-    ],
-    ids=[
-        "PaperlessResource",
-        "CustomFieldType",
-        "MatchingAlgorithm",
-        "ShareLinkFileVersion",
-        "StatusType",
-        "TaskType",
-        "TaskStatus",
-        "WorkflowActionType",
-        "WorkflowTriggerType",
-        "WorkflowTriggerScheduleDateField",
-        "WorkflowTriggerSource",
-        "OutputType",
-        "SavedViewDisplayMode",
+def _unknown_fallback_enums() -> list[type[Enum]]:
+    """Collect every library enum that maps unrecognised values onto UNKNOWN.
+
+    Discovered rather than hand-listed so a new enum cannot slip past this test.
+    """
+    found: dict[str, type[Enum]] = {}
+    for module_info in pkgutil.walk_packages(pypaperless.__path__, f"{pypaperless.__name__}."):
+        module = importlib.import_module(module_info.name)
+        for obj in vars(module).values():
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, Enum)
+                and obj.__module__.startswith(pypaperless.__name__)
+                and "UNKNOWN" in obj.__members__
+                and "_missing_" in obj.__dict__
+            ):
+                found[f"{obj.__module__}.{obj.__qualname__}"] = obj
+    return [found[key] for key in sorted(found)]
+
+
+def test_unknown_fallback_enum_discovery() -> None:
+    """The discovery helper must find enums across all model subpackages."""
+    names = {enum_cls.__name__ for enum_cls in _unknown_fallback_enums()}
+    assert {
         "ImapSecurity",
-        "MailAccountType",
-        "MailRuleAction",
-        "MailRuleTitleSource",
-        "MailRuleCorrespondentSource",
-        "MailRuleAttachmentType",
-        "MailRuleConsumptionScope",
-        "MailRulePdfLayout",
-    ],
+        "OcrMode",
+        "PaperlessResource",
+        "ShareLinkBundleStatus",
+        "TaskTriggerSource",
+        "WorkflowTriggerType",
+    } <= names
+
+
+@pytest.mark.parametrize(
+    "enum_cls",
+    _unknown_fallback_enums(),
+    ids=lambda enum_cls: enum_cls.__name__,
 )
-def test_enum_unknown_fallback(enum_cls: type[Any], bad_value: object) -> None:
+@pytest.mark.parametrize("bad_value", [_NEVER_STR, _NEVER_INT], ids=["str", "int"])
+def test_enum_unknown_fallback(enum_cls: type[Enum], bad_value: object) -> None:
     """Every custom enum must return UNKNOWN for unrecognised values instead of raising."""
     assert enum_cls(bad_value) == enum_cls.UNKNOWN
 
@@ -174,7 +147,7 @@ def test_display_field_value_passthrough_custom() -> None:
 def test_display_field_value_serialises_to_str() -> None:
     """SavedViewCustomFieldDisplay round-trips through JSON as a plain string."""
     result = _ta.validate_python("custom_field_8")
-    assert _ta.dump_python(result) == "custom_field_8"
+    assert _ta.dump_json(result) == b'"custom_field_8"'
 
 
 def test_display_field_value_non_string_raises() -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -63,11 +63,6 @@ def test_enum_unknown_fallback(enum_cls: type[Enum], bad_value: object) -> None:
     assert enum_cls(bad_value) == enum_cls.UNKNOWN
 
 
-# ---------------------------------------------------------------------------
-# CustomFieldDisplay
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     ("raw", "expected_pk"),
     [
@@ -95,10 +90,6 @@ def test_saved_view_custom_field_display_invalid(bad: str) -> None:
     with pytest.raises(ValueError, match="Not a custom field display value"):
         SavedViewCustomFieldDisplay(bad)
 
-
-# ---------------------------------------------------------------------------
-# SavedViewDisplayField coercion
-# ---------------------------------------------------------------------------
 
 _ta: TypeAdapter[SavedViewDisplayField | SavedViewCustomFieldDisplay] = TypeAdapter(
     _DisplayFieldValue


### PR DESCRIPTION
## Why

The suite checked how responses are parsed, barely what the client sends. Every
gap below stayed green under a mutation of the library code.

## Bug fix

`_FormDataBuilder` stringified file-like values, so `documents.versions.upload()`
sent `document=<_io.BytesIO object at 0x...>` instead of the file — **HTTP 415**
against a real server. Found by giving the version-upload test a real assertion.

## Tests

- Request bodies are now verified: `update()` PATCH delta vs. PUT, `full_perms`,
  profile fields, `version_label`, search/tasks/mail/email/chat payloads.
  `trash.restore()` could have sent `{"action": "empty"}` unnoticed — that
  permanently deletes documents.
- Iteration assertions sat inside the loop, so empty results satisfied them.
  Mutating `Page.items` to `[]` now fails 101 tests instead of 0.
- `test_filters.py` could not fail for its own purpose; it now compares query
  params against the kwargs passed.
- `test_settings_token_is_secret` failed whenever `PYPAPERLESS_TOKEN` was set.
- Cleanup: dead mappings/fixtures, 54 dividers, 22 stale line-number docstrings,
  both `noqa`s. `tests/` now has zero suppressions.
