### PR TITLE
ci: collapse redundant PR Labels runs into one

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -3,12 +3,18 @@ name: PR Labels
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - labeled
       - unlabeled
   workflow_call:
+
+# GitHub emits one `labeled` event per label, so a bot applying five labels
+# queues five runs within a second. Only the latest label state matters.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions: {}
 


### PR DESCRIPTION
## Proposed change

**PR Labels** ran once per label. GitHub emits a separate `labeled` event per label rather than one per API call, and the workflow had no `concurrency` group — so every event became a full run. Renovate PR #705 produced 11 runs in two seconds, #704 six (1× `opened` plus one per label).

Two changes:

1. **A per-PR `concurrency` group with `cancel-in-progress`.** Only the newest run has a current label state, so the burst collapses to one completed run and the rest are dropped while still queued. The group falls back to `github.ref` so the retained `workflow_call:` trigger cannot put unrelated invocations into one shared group.
2. **`pull_request_target` → `pull_request`.** The job reads label names from the event payload and declares `permissions: {}`, so it needs neither secrets nor a write-capable token. Fork PRs still trigger it, just with a read-only token.

The check name stays `PR Labels / Verify`, so branch protection is unaffected. Because `pull_request` definitions are read from the PR head, the trigger change only applies to PRs opened or re-labelled after this merges.

## Type of change

<!-- Please check exactly one box. If more than one applies, consider splitting the PR. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Code quality, refactor or performance (no functional change)
- [ ] Documentation
- [x] CI, tooling or dependency update

## Breaking change

Not applicable.

## Related issues

No related issue — spotted directly in the Actions run history.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] AI and agentic coding tools are very welcome here. If I used one, I have read and reviewed its entire output myself and take responsibility for it.
- [ ] `uv run pytest -x -q` passes locally and coverage stays at 95 % or above.
- [ ] `prek run --all-files` passes (ruff, mypy, codespell, yamllint).
- [ ] Tests have been added or updated for the changed behavior.
- [ ] (OPTIONAL) The docs in `docs/` have been updated if the public API changed.
- [ ] (OPTIONAL) `uv run python script/pngx_smoketest.py` passed against a live instance, or the change cannot affect live API interaction.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4vRNEazzX63EV1PF2RjGJ