### PR TITLE
ci: poll for the labels to land before failing the label check

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -33,25 +33,41 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          MAX_ATTEMPTS: "8"
+          RETRY_DELAY: "5"
           VALID_LABELS: >-
             breaking-change bugfix ci dependencies documentation
             enhancement maintenance new-feature performance refactor
         run: |
-          # Renovate opens the PR first and applies its labels in a second API
-          # call, so the event payload can carry a label set that is already
-          # stale by the time this runs. A failure here sticks to the commit
-          # for good, so read the live state instead.
-          labels="$(gh api "repos/${PR_REPO}/pulls/${PR_NUMBER}" --jq '.labels[].name')"
-
+          # A bot opens the PR first and applies its labels in a second API
+          # call, so both the event payload and an immediate read can see an
+          # empty set — this job has finished within 7s of a PR being opened.
+          # A failure sticks to the commit for good, so poll for the labels to
+          # land before calling a PR unlabelled.
           matched=""
-          while IFS= read -r label; do
-            [ -n "$label" ] || continue
-            for valid in $VALID_LABELS; do
-              if [ "$label" = "$valid" ]; then
-                matched="${matched:+$matched, }$label"
-              fi
-            done
-          done <<< "$labels"
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if ! labels="$(gh api "repos/${PR_REPO}/pulls/${PR_NUMBER}" --jq '.labels[].name')"; then
+              labels=""
+            fi
+
+            while IFS= read -r label; do
+              [ -n "$label" ] || continue
+              for valid in $VALID_LABELS; do
+                if [ "$label" = "$valid" ]; then
+                  matched="${matched:+$matched, }$label"
+                fi
+              done
+            done <<< "$labels"
+
+            if [ -n "$matched" ]; then
+              break
+            fi
+
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "No valid label yet (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${RETRY_DELAY}s"
+              sleep "$RETRY_DELAY"
+            fi
+          done
 
           if [ -z "$matched" ]; then
             echo "::error title=Missing label::This PR needs at least one of these labels: ${VALID_LABELS}"


### PR DESCRIPTION
## Proposed change

Follow-up to #709, which left one hole open — and #709 itself walked straight into it.

#709 replaced the event payload with a live API read, on the reasoning that the payload is a
snapshot taken when the PR is opened while labels are applied in a later call. That reasoning was
right but the remedy was too weak: on #709 the `opened` run finished **seven seconds** after the
pull request was created, before any label had been applied, and failed against an empty set. The
run is still on `c94211a` with conclusion `failure`.

This matters more than a stray red X. Renovate maps a `cancelled` run to *pending* but a `failure`
to *red*, and it evaluates every check run on the head commit rather than the latest one per name.
A pending branch heals on the next rebase; a red one does not. Since #709 also turned
`cancel-in-progress` off, those early runs now survive to completion instead of being killed, so
the window is open on `main` today.

So treat an empty label set as "not yet" rather than "missing": poll the API up to eight times at
five-second intervals before concluding a pull request is unlabelled. A genuinely unlabelled pull
request still fails, forty seconds later. `gh api` failures are folded into the same retry rather
than aborting the job, so a transient API blip cannot weld a red conclusion either.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Code quality, refactor or performance (no functional change)
- [ ] Documentation
- [x] CI, tooling or dependency update

## Breaking change

n/a

## Related issues

- Follow-up to #709

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] AI and agentic coding tools are very welcome here. If I used one, I have read and reviewed its entire output myself and take responsibility for it.
- [x] `uv run pytest -x -q` passes locally and coverage stays at 95 % or above.
- [ ] `prek run --all-files` passes (ruff, mypy, codespell, yamllint).
- [ ] Tests have been added or updated for the changed behavior.
- [ ] (OPTIONAL) The docs in `docs/` have been updated if the public API changed.
- [x] (OPTIONAL) `uv run python script/pngx_smoketest.py` passed against a live instance, or the change cannot affect live API interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Si4cNBsGtddZhKhNM2VWV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Si4cNBsGtddZhKhNM2VWV7)_